### PR TITLE
Remove dead link from examples

### DIFF
--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -135,8 +135,6 @@ ${project.name}
 
   * {{{./examples/deploying-with-classifiers.html}Deploy an artifact with classifier}}
 
-  * {{{./examples/disabling-timestamps-suffix.html}Disable timestamps suffix in an artifact}}
-
   * {{{./examples/deploying-in-legacy-layout.html}Deploy an artifact in legacy layout}}
 
    []


### PR DESCRIPTION
Remove link to 'Disable timestamps suffix in an artifact' examples page that was removed in commit bb00fae8bc656e63ac54560307e4cbb0ad1a8025.

As an aside, is the 'https://maven.apache.org/plugins/maven-deploy-plugin/' still the home page for this plugin?  Plans to maintain that site, or unpublish it and transition to Markdown documentation on GutHub?  Just curious!  It seems like 'https://maven.apache.org/plugins/' does not link to the individual plugin sites.

Thanks!