### PR TITLE
MDEPLOY-245: Remove the remnants of the obsolete `updateReleaseInfo` parameter.

### DIFF
--- a/src/it/3rd-party-jar-with-extras/test.properties
+++ b/src/it/3rd-party-jar-with-extras/test.properties
@@ -17,7 +17,6 @@
 
 file = test-0.1.jar
 url = file:target/repo
-updateReleaseInfo = true
 groupId = org.apache.maven.its.deploy.tpjwop
 artifactId = test
 version = 1.0

--- a/src/it/3rd-party-jar-without-pom/test.properties
+++ b/src/it/3rd-party-jar-without-pom/test.properties
@@ -17,7 +17,6 @@
 
 file = test-0.1.jar
 url = file:target/repo
-updateReleaseInfo = true
 groupId = org.apache.maven.its.deploy.tpjwop
 artifactId = test
 version = 1.0

--- a/src/it/3rd-party-pom-with-extras/test.properties
+++ b/src/it/3rd-party-pom-with-extras/test.properties
@@ -17,7 +17,6 @@
 
 file = test-0.1.pom
 url = file:target/repo
-updateReleaseInfo = true
 groupId = org.apache.maven.its.deploy.tppwoc
 artifactId = test
 version = 1.0

--- a/src/it/attach-release-jar/pom.xml
+++ b/src/it/attach-release-jar/pom.xml
@@ -33,7 +33,6 @@ under the License.
 
   <properties>
     <maven.test.skip>true</maven.test.skip>
-    <updateReleaseInfo>true</updateReleaseInfo>
   </properties>
 
   <distributionManagement>

--- a/src/it/external-release-jar/test.properties
+++ b/src/it/external-release-jar/test.properties
@@ -18,4 +18,3 @@
 file = test-0.1.jar
 pomFile = test-0.1.pom
 url = file:target/repo
-updateReleaseInfo = true

--- a/src/it/release-jar/pom.xml
+++ b/src/it/release-jar/pom.xml
@@ -33,7 +33,6 @@ under the License.
 
   <properties>
     <maven.test.skip>true</maven.test.skip>
-    <updateReleaseInfo>true</updateReleaseInfo>
   </properties>
 
   <distributionManagement>

--- a/src/it/release-pom/pom.xml
+++ b/src/it/release-pom/pom.xml
@@ -33,7 +33,6 @@ under the License.
 
   <properties>
     <maven.test.skip>true</maven.test.skip>
-    <updateReleaseInfo>true</updateReleaseInfo>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
Jira: MDEPLOY-240 - trivial follow-up fix.

 - [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
