### PR TITLE
[MDEPLOY-265] Maintain backwards compatibility for alt*DeploymentRepository in id::default::url format

### DIFF
--- a/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java
+++ b/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java
@@ -259,10 +259,9 @@ public class DeployMojo
 
                 if ( "default".equals( layout ) )
                 {
-                    throw new MojoFailureException( altDeploymentRepo,
-                            "Invalid legacy syntax for repository.",
-                            "Invalid legacy syntax for alternative repository. Use \"" + id + "::" + url + "\" instead."
-                    );
+                    getLog().warn( "Using legacy syntax for alternative repository. "
+                            + "Use \"" + id + "::" + url + "\" instead." );
+                    repo = createDeploymentArtifactRepository( id, url );
                 }
                 else
                 {

--- a/src/test/java/org/apache/maven/plugins/deploy/DeployMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/deploy/DeployMojoTest.java
@@ -568,16 +568,10 @@ public class DeployMojoTest
             new ProjectDeployerRequest()
                 .setProject( project )
                 .setAltDeploymentRepository( "altDeploymentRepository::default::http://localhost" );
-        try
-        {
-            mojo.getDeploymentRepository( pdr );
-            fail( "Should throw: Invalid legacy syntax for repository." );
-        }
-        catch( MojoFailureException e )
-        {
-            assertEquals( e.getMessage(), "Invalid legacy syntax for repository.");
-            assertEquals( e.getLongMessage(), "Invalid legacy syntax for alternative repository. Use \"altDeploymentRepository::http://localhost\" instead.");
-        }
+
+        assertEquals( repository,
+                mojo.getDeploymentRepository( pdr ));
+
     }
 
     public void testLegacyAltDeploymentRepositoryWithLegacyLayout()
@@ -640,7 +634,7 @@ public class DeployMojoTest
         DeployMojo mojo = spy( new DeployMojo() );
 
         ArtifactRepository repository = mock( ArtifactRepository.class );
-        when( mojo.createDeploymentArtifactRepository( "altDeploymentRepository", "http://localhost"
+        when( mojo.createDeploymentArtifactRepository( "altDeploymentRepository", "scm:svn:http://localhost"
         ) ).thenReturn( repository );
 
         project.setVersion( "1.0-SNAPSHOT" );
@@ -649,16 +643,9 @@ public class DeployMojoTest
                 new ProjectDeployerRequest()
                         .setProject( project )
                         .setAltDeploymentRepository( "altDeploymentRepository::default::scm:svn:http://localhost" );
-        try
-        {
-            mojo.getDeploymentRepository( pdr );
-            fail( "Should throw: Invalid legacy syntax for repository." );
-        }
-        catch( MojoFailureException e )
-        {
-            assertEquals( e.getMessage(), "Invalid legacy syntax for repository.");
-            assertEquals( e.getLongMessage(), "Invalid legacy syntax for alternative repository. Use \"altDeploymentRepository::scm:svn:http://localhost\" instead.");
-        }
+
+        assertEquals( repository,
+                mojo.getDeploymentRepository( pdr ));
     }
     public void testLegacyScmSvnAltDeploymentRepository()
             throws Exception


### PR DESCRIPTION
[[MDEPLOY-265](https://issues.apache.org/jira/browse/MDEPLOY-265)] Maintain backwards compatibility for `alt*DeploymentRepository` in `id::default::url` format

The legacy format (<=2.x) of `alt*DeploymentRepository` is `id::layout::url`.
The new format (>= 3.x) of `alt*DeploymentRepository` is `id::url`, which is equivalent to `id::default::url` from the legacy format.

This change introduces backwards compatibility with 2.x by supporting `alt*DeploymentRepository` values in the `id::layout::url` format if and only if the layout is equal to `default`.  The `default` layout is the most commonly used layout, so this should maintain backwards compatibility with the large majority of projects using the `alt*DeploymentRepository` properties.

Usage of the legacy format with the `default` layout will result in a warning message being logged.
Usage of the legacy format with layouts other than `default` will result in an exception being thrown.

One use case this change will help is when `alt*DeploymentRepository` properties are set in common maven `settings.xml` files used for a large number of projects.  For example, a CI server.  Keeping backwards compatibility with `id::default::url` allows those `settings.xml` files to be used regardless of the version of maven-deploy-plugin used by the projects built on that CI server.  Projects can individually upgrade their maven-deploy-plugin without breaking.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MPH) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MPH-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MPH-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

