### PR TITLE
Update plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <mavenVersion>3.0</mavenVersion>
+    <mavenVersion>3.1.1</mavenVersion>
     <javaVersion>7</javaVersion>
     <project.build.outputTimestamp>2020-04-07T21:04:00Z</project.build.outputTimestamp>
   </properties>
@@ -93,7 +93,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-artifact-transfer</artifactId>
-      <version>0.13.1</version>
+      <version>2.0.0-SNAPSHOT</version>
     </dependency>
     <!-- Upgrade of transitive dependency. -->
     <dependency>
@@ -116,7 +116,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
-      <version>2.1</version>
+      <version>3.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency> <!-- used by maven-plugin-testing-harness, don't give it compile scope! -->
@@ -134,25 +134,25 @@ under the License.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.aether</groupId>
+      <groupId>org.eclipse.aether</groupId>
       <artifactId>aether-connector-file</artifactId>
-      <version>1.7</version>
+      <version>0.9.0.M2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.5</version>
+      <version>1.7.32</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
-      <version>1.7.5</version>
+      <version>1.7.32</version>
       <scope>test</scope>
     </dependency>
     

--- a/src/test/java/org/apache/maven/plugins/deploy/DeployFileMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/deploy/DeployFileMojoTest.java
@@ -30,11 +30,13 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Model;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.repository.internal.MavenRepositorySystemSession;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
+import org.eclipse.aether.repository.LocalRepository;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
 
 /**
  * @author <a href="mailto:aramirez@apache.org">Allan Ramirez</a>
@@ -92,8 +94,8 @@ public class DeployFileMojoTest
         
         ProjectBuildingRequest buildingRequest = mock ( ProjectBuildingRequest.class );
         when( session.getProjectBuildingRequest() ).thenReturn( buildingRequest );
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( LOCAL_REPO ) );
+        DefaultRepositorySystemSession repositorySession  = new DefaultRepositorySystemSession();
+        repositorySession.setLocalRepositoryManager( new EnhancedLocalRepositoryManagerFactory().newInstance( mock( RepositorySystemSession.class ), new LocalRepository(LOCAL_REPO) ) );
         when( buildingRequest.getRepositorySession() ).thenReturn( repositorySession );
         
         String groupId = (String) getVariableValueFromObject( mojo, "groupId" );
@@ -193,8 +195,8 @@ public class DeployFileMojoTest
         
         ProjectBuildingRequest buildingRequest = mock ( ProjectBuildingRequest.class );
         when( session.getProjectBuildingRequest() ).thenReturn( buildingRequest );
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( LOCAL_REPO ) );
+        DefaultRepositorySystemSession repositorySession  = new DefaultRepositorySystemSession();
+        repositorySession.setLocalRepositoryManager( new EnhancedLocalRepositoryManagerFactory().newInstance( mock( RepositorySystemSession.class ), new LocalRepository(LOCAL_REPO) ) );
         when( buildingRequest.getRepositorySession() ).thenReturn( repositorySession );
 
         String classifier = ( String ) getVariableValueFromObject( mojo, "classifier" );
@@ -241,8 +243,8 @@ public class DeployFileMojoTest
         
         ProjectBuildingRequest buildingRequest = mock ( ProjectBuildingRequest.class );
         when( session.getProjectBuildingRequest() ).thenReturn( buildingRequest );
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( LOCAL_REPO ) );
+        DefaultRepositorySystemSession repositorySession  = new DefaultRepositorySystemSession();
+        repositorySession.setLocalRepositoryManager( new EnhancedLocalRepositoryManagerFactory().newInstance( mock( RepositorySystemSession.class ), new LocalRepository(LOCAL_REPO) ) );
         when( buildingRequest.getRepositorySession() ).thenReturn( repositorySession );
 
         String groupId = (String) getVariableValueFromObject( mojo, "groupId" );

--- a/src/test/java/org/apache/maven/plugins/deploy/DeployMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/deploy/DeployMojoTest.java
@@ -40,14 +40,16 @@ import org.apache.maven.plugins.deploy.stubs.ArtifactRepositoryStub;
 import org.apache.maven.plugins.deploy.stubs.DeployArtifactStub;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.apache.maven.shared.transfer.project.deploy.ProjectDeployerRequest;
 import org.codehaus.plexus.util.FileUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
+import org.eclipse.aether.repository.LocalRepository;
 import org.junit.Ignore;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
 
 /**
  * @author <a href="mailto:aramirez@apache.org">Allan Ramirez</a>
@@ -132,8 +134,8 @@ public class DeployMojoTest
         
         ProjectBuildingRequest buildingRequest = mock ( ProjectBuildingRequest.class );
         when( session.getProjectBuildingRequest() ).thenReturn( buildingRequest );
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( LOCAL_REPO ) );
+        DefaultRepositorySystemSession repositorySession  = new DefaultRepositorySystemSession();
+        repositorySession.setLocalRepositoryManager( new EnhancedLocalRepositoryManagerFactory().newInstance( mock( RepositorySystemSession.class ), new LocalRepository(LOCAL_REPO) ) );
         when( buildingRequest.getRepositorySession() ).thenReturn( repositorySession );
         
         File file = new File( getBasedir(),
@@ -303,8 +305,8 @@ public class DeployMojoTest
         
         ProjectBuildingRequest buildingRequest = mock ( ProjectBuildingRequest.class );
         when( session.getProjectBuildingRequest() ).thenReturn( buildingRequest );
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( LOCAL_REPO ) );
+        DefaultRepositorySystemSession repositorySession  = new DefaultRepositorySystemSession();
+        repositorySession.setLocalRepositoryManager( new EnhancedLocalRepositoryManagerFactory().newInstance( mock( RepositorySystemSession.class ), new LocalRepository(LOCAL_REPO) ) );
         when( buildingRequest.getRepositorySession() ).thenReturn( repositorySession );
         
         File pomFile = new File( getBasedir(),
@@ -415,8 +417,8 @@ public class DeployMojoTest
         
         ProjectBuildingRequest buildingRequest = mock ( ProjectBuildingRequest.class );
         when( session.getProjectBuildingRequest() ).thenReturn( buildingRequest );
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( LOCAL_REPO ) );
+        DefaultRepositorySystemSession repositorySession  = new DefaultRepositorySystemSession();
+        repositorySession.setLocalRepositoryManager( new EnhancedLocalRepositoryManagerFactory().newInstance( mock( RepositorySystemSession.class ), new LocalRepository(LOCAL_REPO) ) );
         when( buildingRequest.getRepositorySession() ).thenReturn( repositorySession );
 
         MavenProject project = (MavenProject) getVariableValueFromObject( mojo, "project" );

--- a/src/test/java/org/apache/maven/plugins/deploy/Utils.java
+++ b/src/test/java/org/apache/maven/plugins/deploy/Utils.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.plugin.MojoExecutionException;
-import org.sonatype.aether.util.ChecksumUtils;
+import org.eclipse.aether.util.ChecksumUtils;
 
 /**
  * A utility class to assist testing.


### PR DESCRIPTION
to forget org.sonatype stuff (that was still used in UT!)
in version 3.0.0-M1!!!

Also, bump m-a-t to 2.0.0-SNAP to run ITs.

Changes:
* update maven version to 3.1.1
* align plugin test harness version with maven version
* up various deps
* rework UTs: drop use of org.sonatype Aether switch to maven 3.1.1 Aether (org.eclipse)
