### PR TITLE
[MDEPLOY-291] Update POM parent and Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@ under the License.
 
   <properties>
     <mavenVersion>3.8.5</mavenVersion>
+    <slf4j.version>1.7.36</slf4j.version>
     <resolverVersion>1.6.3</resolverVersion> <!-- Keep in sync with resolver used in maven above -->
     <javaVersion>8</javaVersion>
     <project.build.outputTimestamp>2021-12-27T14:11:19Z</project.build.outputTimestamp>
@@ -98,7 +99,7 @@ under the License.
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.36</version>
+      <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -176,7 +177,7 @@ under the License.
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
-      <version>1.7.36</version>
+      <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
     

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@ under the License.
   <parent>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-plugins</artifactId>
-    <version>34</version>
-    <relativePath>../../pom/maven/maven-plugins/pom.xml</relativePath>
+    <version>36</version>
+    <relativePath/>
   </parent>
 
   <artifactId>maven-deploy-plugin</artifactId>
@@ -63,8 +63,9 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <mavenVersion>3.0</mavenVersion>
-    <javaVersion>7</javaVersion>
+    <mavenVersion>3.8.5</mavenVersion>
+    <resolverVersion>1.6.3</resolverVersion> <!-- Keep in sync with resolver used in maven above -->
+    <javaVersion>8</javaVersion>
     <project.build.outputTimestamp>2021-12-27T14:11:19Z</project.build.outputTimestamp>
   </properties>
 
@@ -73,50 +74,61 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.36</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-artifact-transfer</artifactId>
       <version>0.13.1</version>
     </dependency>
-    <!-- Upgrade of transitive dependency. -->
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.5</version>
+      <version>2.11.0</version>
     </dependency>
-    
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.4.1</version>
+    </dependency>
+
     <!-- dependencies to annotations -->
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-      <version>3.2.0</version>
-    </dependency>
+
+    <!-- Test -->
     <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
-      <version>2.1</version>
+      <version>3.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency> <!-- used by maven-plugin-testing-harness, don't give it compile scope! -->
@@ -126,33 +138,45 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-resolver-provider</artifactId>
+      <version>${mavenVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-connector-basic</artifactId>
+      <version>${resolverVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-file</artifactId>
+      <version>${resolverVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-http</artifactId>
+      <version>${resolverVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.28.2</version>
+      <version>4.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.sonatype.aether</groupId>
-      <artifactId>aether-connector-file</artifactId>
-      <version>1.7</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.5</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
-      <version>1.7.5</version>
+      <version>1.7.36</version>
       <scope>test</scope>
     </dependency>
     

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@ under the License.
 
   <properties>
     <mavenVersion>3.2.5</mavenVersion>
-    <slf4j.version>1.7.5</slf4j.version> <!-- Keep in sync with resolver used in maven above -->
+    <slf4jVersion>1.7.5</slf4jVersion> <!-- Keep in sync with resolver used in maven above -->
     <resolverVersion>1.0.0.v20140518</resolverVersion> <!-- Keep in sync with resolver used in maven above -->
     <javaVersion>7</javaVersion>
     <project.build.outputTimestamp>2021-12-27T14:11:19Z</project.build.outputTimestamp>
@@ -99,7 +99,7 @@ under the License.
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
+      <version>${slf4jVersion}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -187,7 +187,7 @@ under the License.
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
-      <version>${slf4j.version}</version>
+      <version>${slf4jVersion}</version>
       <scope>test</scope>
     </dependency>
     

--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,10 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <mavenVersion>3.8.5</mavenVersion>
-    <slf4j.version>1.7.36</slf4j.version>
-    <resolverVersion>1.6.3</resolverVersion> <!-- Keep in sync with resolver used in maven above -->
-    <javaVersion>8</javaVersion>
+    <mavenVersion>3.2.5</mavenVersion>
+    <slf4j.version>1.7.5</slf4j.version> <!-- Keep in sync with resolver used in maven above -->
+    <resolverVersion>1.0.0.v20140518</resolverVersion> <!-- Keep in sync with resolver used in maven above -->
+    <javaVersion>7</javaVersion>
     <project.build.outputTimestamp>2021-12-27T14:11:19Z</project.build.outputTimestamp>
   </properties>
 
@@ -110,12 +110,22 @@ under the License.
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.11.0</version>
+      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.4.1</version>
+      <version>3.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-api</artifactId>
+      <version>${resolverVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-util</artifactId>
+      <version>${resolverVersion}</version>
     </dependency>
 
     <!-- dependencies to annotations -->
@@ -140,32 +150,32 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-resolver-provider</artifactId>
+      <artifactId>maven-aether-provider</artifactId>
       <version>${mavenVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-connector-basic</artifactId>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-connector-basic</artifactId>
       <version>${resolverVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-transport-file</artifactId>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-transport-file</artifactId>
       <version>${resolverVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-transport-http</artifactId>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-transport-http</artifactId>
       <version>${resolverVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.4.0</version>
+      <version>2.28.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/apache/maven/plugins/deploy/DeployFileMojo.java
+++ b/src/main/java/org/apache/maven/plugins/deploy/DeployFileMojo.java
@@ -481,6 +481,7 @@ public class DeployFileMojo
 
         try
         {
+            warnIfAffectedPackagingAndMaven( packaging );
             artifactDeployer.deploy( getSession().getProjectBuildingRequest(), deploymentRepository,
                                      deployableArtifacts );
         }

--- a/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java
+++ b/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java
@@ -207,6 +207,7 @@ public class DeployMojo
     {
         try
         {
+            warnIfAffectedPackagingAndMaven( pir.getProject().getPackaging() );
             projectDeployer.deploy( pbr, pir, repo );
         }
         catch ( NoFileAssignedException e )

--- a/src/test/java/org/apache/maven/plugins/deploy/DeployFileMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/deploy/DeployFileMojoTest.java
@@ -30,11 +30,12 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Model;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.repository.internal.MavenRepositorySystemSession;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.repository.LocalRepository;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
+import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 
 /**
  * @author <a href="mailto:aramirez@apache.org">Allan Ramirez</a>
@@ -91,9 +92,10 @@ public class DeployFileMojoTest
         assertNotNull( mojo );
         
         ProjectBuildingRequest buildingRequest = mock ( ProjectBuildingRequest.class );
+        when( buildingRequest.getRepositoryMerging() ).thenReturn( ProjectBuildingRequest.RepositoryMerging.POM_DOMINANT );
         when( session.getProjectBuildingRequest() ).thenReturn( buildingRequest );
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( LOCAL_REPO ) );
+        DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
+        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManagerFactory().newInstance( repositorySession, new LocalRepository( LOCAL_REPO ) ) );
         when( buildingRequest.getRepositorySession() ).thenReturn( repositorySession );
         
         String groupId = (String) getVariableValueFromObject( mojo, "groupId" );
@@ -192,9 +194,10 @@ public class DeployFileMojoTest
         assertNotNull( mojo );
         
         ProjectBuildingRequest buildingRequest = mock ( ProjectBuildingRequest.class );
+        when( buildingRequest.getRepositoryMerging() ).thenReturn( ProjectBuildingRequest.RepositoryMerging.POM_DOMINANT );
         when( session.getProjectBuildingRequest() ).thenReturn( buildingRequest );
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( LOCAL_REPO ) );
+        DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
+        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManagerFactory().newInstance( repositorySession, new LocalRepository( LOCAL_REPO ) ) );
         when( buildingRequest.getRepositorySession() ).thenReturn( repositorySession );
 
         String classifier = ( String ) getVariableValueFromObject( mojo, "classifier" );
@@ -240,9 +243,10 @@ public class DeployFileMojoTest
         assertNotNull( mojo );
         
         ProjectBuildingRequest buildingRequest = mock ( ProjectBuildingRequest.class );
+        when( buildingRequest.getRepositoryMerging() ).thenReturn( ProjectBuildingRequest.RepositoryMerging.POM_DOMINANT );
         when( session.getProjectBuildingRequest() ).thenReturn( buildingRequest );
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( LOCAL_REPO ) );
+        DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
+        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManagerFactory().newInstance( repositorySession, new LocalRepository( LOCAL_REPO ) ) );
         when( buildingRequest.getRepositorySession() ).thenReturn( repositorySession );
 
         String groupId = (String) getVariableValueFromObject( mojo, "groupId" );

--- a/src/test/java/org/apache/maven/plugins/deploy/DeployMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/deploy/DeployMojoTest.java
@@ -40,14 +40,15 @@ import org.apache.maven.plugins.deploy.stubs.ArtifactRepositoryStub;
 import org.apache.maven.plugins.deploy.stubs.DeployArtifactStub;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.apache.maven.shared.transfer.project.deploy.ProjectDeployerRequest;
 import org.codehaus.plexus.util.FileUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.repository.LocalRepository;
 import org.junit.Ignore;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
+import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 
 /**
  * @author <a href="mailto:aramirez@apache.org">Allan Ramirez</a>
@@ -132,8 +133,8 @@ public class DeployMojoTest
         
         ProjectBuildingRequest buildingRequest = mock ( ProjectBuildingRequest.class );
         when( session.getProjectBuildingRequest() ).thenReturn( buildingRequest );
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( LOCAL_REPO ) );
+        DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
+        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManagerFactory().newInstance( repositorySession, new LocalRepository( LOCAL_REPO ) ) );
         when( buildingRequest.getRepositorySession() ).thenReturn( repositorySession );
         
         File file = new File( getBasedir(),
@@ -303,8 +304,8 @@ public class DeployMojoTest
         
         ProjectBuildingRequest buildingRequest = mock ( ProjectBuildingRequest.class );
         when( session.getProjectBuildingRequest() ).thenReturn( buildingRequest );
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( LOCAL_REPO ) );
+        DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
+        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManagerFactory().newInstance( repositorySession, new LocalRepository( LOCAL_REPO ) ) );
         when( buildingRequest.getRepositorySession() ).thenReturn( repositorySession );
         
         File pomFile = new File( getBasedir(),
@@ -415,8 +416,8 @@ public class DeployMojoTest
         
         ProjectBuildingRequest buildingRequest = mock ( ProjectBuildingRequest.class );
         when( session.getProjectBuildingRequest() ).thenReturn( buildingRequest );
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( LOCAL_REPO ) );
+        DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
+        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManagerFactory().newInstance( repositorySession, new LocalRepository( LOCAL_REPO ) ) );
         when( buildingRequest.getRepositorySession() ).thenReturn( repositorySession );
 
         MavenProject project = (MavenProject) getVariableValueFromObject( mojo, "project" );

--- a/src/test/java/org/apache/maven/plugins/deploy/Utils.java
+++ b/src/test/java/org/apache/maven/plugins/deploy/Utils.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.plugin.MojoExecutionException;
-import org.sonatype.aether.util.ChecksumUtils;
+import org.eclipse.aether.util.ChecksumUtils;
 
 /**
  * A utility class to assist testing.

--- a/src/test/java/org/apache/maven/plugins/deploy/stubs/ArtifactRepositoryStub.java
+++ b/src/test/java/org/apache/maven/plugins/deploy/stubs/ArtifactRepositoryStub.java
@@ -132,13 +132,13 @@ public class ArtifactRepositoryStub
         return blacklisted;
     }
 
-    @Override
+    // @Override
     public boolean isBlocked()
     {
         return false;
     }
 
-    @Override
+    // @Override
     public void setBlocked( boolean b )
     {
 

--- a/src/test/java/org/apache/maven/plugins/deploy/stubs/ArtifactRepositoryStub.java
+++ b/src/test/java/org/apache/maven/plugins/deploy/stubs/ArtifactRepositoryStub.java
@@ -131,4 +131,16 @@ public class ArtifactRepositoryStub
     {
         return blacklisted;
     }
+
+    @Override
+    public boolean isBlocked()
+    {
+        return false;
+    }
+
+    @Override
+    public void setBlocked( boolean b )
+    {
+
+    }
 }


### PR DESCRIPTION
Update plugin build:
* update parent to 36
* update maven to 3.2.5
* leave the plugin to Java7
* warn user if older that Maven 3.9.0 is used to deploy a maven-plugin

~This plugin along with m-install-p versions 3.x line (3.0.0-Mx) does not work with any so far released Maven 3.x line (see MNG-7055). The ONLY maven 3.x they will be usable with is upcoming 3.9.0, that has fix for MNG-7055 backported, but OTOH, it is already Java8, so no point in keeping the plugin on anything below.~ This all stands, but ONLY for maven-plugin packaging.

---

https://issues.apache.org/jira/browse/MDEPLOY-291