### PR TITLE
DeployFileMojo#readModel(File): fixed MojoExecutionException javadoc

### DIFF
--- a/src/main/java/org/apache/maven/plugins/deploy/DeployFileMojo.java
+++ b/src/main/java/org/apache/maven/plugins/deploy/DeployFileMojo.java
@@ -426,7 +426,7 @@ public class DeployFileMojo extends AbstractDeployMojo {
      *
      * @param pomFile The path of the POM file to parse, must not be <code>null</code>.
      * @return The model from the POM file, never <code>null</code>.
-     * @throws MojoExecutionException If the file doesn't exist of cannot be read.
+     * @throws MojoExecutionException If the file doesn't exist or cannot be read.
      */
     Model readModel(File pomFile) throws MojoExecutionException {
         Reader reader = null;


### PR DESCRIPTION
This PR fixes the MojoExecutionException Javadoc at `DeployFileMojo#readModel(File)`.
