### PR TITLE
[MDEPLOY-313] Update to parent 41, cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-plugins</artifactId>
-    <version>39</version>
+    <version>41</version>
     <relativePath />
   </parent>
 
@@ -43,7 +43,7 @@ under the License.
   </contributors>
 
   <prerequisites>
-    <maven>${mavenVersion}</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <scm>
@@ -69,23 +69,23 @@ under the License.
 
   <properties>
     <javaVersion>8</javaVersion>
-    <mavenVersion>3.2.5</mavenVersion>
+    <mavenVersion>3.9.6</mavenVersion>
     <!-- Keep in sync with resolver used in maven above -->
-    <slf4jVersion>1.7.5</slf4jVersion>
+    <slf4jVersion>1.7.36</slf4jVersion>
     <!-- Keep in sync with resolver used in maven above -->
-    <resolverVersion>1.0.0.v20140518</resolverVersion>
+    <resolverVersion>1.9.18</resolverVersion>
 
     <!-- plugins version used in IT tests -->
     <mavenAntrunPluginVersion>3.1.0</mavenAntrunPluginVersion>
-    <mavenCompilerPluginVersion>3.10.1</mavenCompilerPluginVersion>
-    <mavenEnforcerPluginVersion>3.1.0</mavenEnforcerPluginVersion>
-    <mavenInstallPluginVersion>3.1.0</mavenInstallPluginVersion>
+    <mavenCompilerPluginVersion>3.12.1</mavenCompilerPluginVersion>
+    <mavenEnforcerPluginVersion>3.4.1</mavenEnforcerPluginVersion>
+    <mavenInstallPluginVersion>3.1.1</mavenInstallPluginVersion>
     <mavenJarPluginVersion>3.3.0</mavenJarPluginVersion>
     <mavenJavadocPluginVersion>3.4.1</mavenJavadocPluginVersion>
     <mavenPluginToolsVersion>${maven.plugin.tools.version}</mavenPluginToolsVersion>
     <mavenResourcesPluginVersion>3.3.0</mavenResourcesPluginVersion>
     <mavenSourcePluginVersion>3.2.1</mavenSourcePluginVersion>
-    <mavenSurefirePluginVersion>${surefire.version}</mavenSurefirePluginVersion>
+    <mavenSurefirePluginVersion>3.2.5</mavenSurefirePluginVersion>
     <mavenWarPluginVersion>3.3.2</mavenWarPluginVersion>
 
     <project.build.outputTimestamp>2023-03-21T14:38:01Z</project.build.outputTimestamp>
@@ -128,14 +128,18 @@ under the License.
       <artifactId>plexus-utils</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-xml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
       <version>${resolverVersion}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
       <version>${resolverVersion}</version>
       <!-- To work in Maven versions older than 3.9.0 -->
       <scope>compile</scope>
@@ -164,25 +168,25 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
+      <artifactId>maven-resolver-provider</artifactId>
       <version>${mavenVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-connector-basic</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-connector-basic</artifactId>
       <version>${resolverVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-file</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-file</artifactId>
       <version>${resolverVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-http</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-http</artifactId>
       <version>${resolverVersion}</version>
       <scope>test</scope>
     </dependency>
@@ -204,8 +208,20 @@ under the License.
       <version>${slf4jVersion}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <proc>none</proc>
+          <showDeprecation>true</showDeprecation>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <profile>

--- a/src/it/MDEPLOY-178_deployfile-with-embedded-pom/verify.groovy
+++ b/src/it/MDEPLOY-178_deployfile-with-embedded-pom/verify.groovy
@@ -25,5 +25,5 @@ File buildLog = new File( basedir, 'build.log' )
 assert buildLog.exists()
 assert buildLog.text.contains( "[DEBUG] Using META-INF/maven/org.apache.maven.plugins.deploy.its/mdeploy178/pom.xml as pomFile" )
 
-def pomProject = new XmlSlurper().parse( deployedPom )
-assert "https://issues.apache.org/jira/browse/MDEPLOY-178".equals( pomProject.url.text() )
+def pomProject = new groovy.xml.XmlParser().parse( deployedPom )
+assert "https://issues.apache.org/jira/browse/MDEPLOY-178".equals( pomProject.get("url").text() )

--- a/src/test/java/org/apache/maven/plugins/deploy/DeployFileMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/deploy/DeployFileMojoTest.java
@@ -28,6 +28,7 @@ import org.apache.maven.model.Model;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.internal.impl.DefaultLocalPathComposer;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
 import org.mockito.InjectMocks;
@@ -86,8 +87,9 @@ public class DeployFileMojoTest extends AbstractMojoTestCase {
         when(buildingRequest.getRepositoryMerging()).thenReturn(ProjectBuildingRequest.RepositoryMerging.POM_DOMINANT);
         when(session.getProjectBuildingRequest()).thenReturn(buildingRequest);
         DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager(new SimpleLocalRepositoryManagerFactory()
-                .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
+        repositorySession.setLocalRepositoryManager(
+                new SimpleLocalRepositoryManagerFactory(new DefaultLocalPathComposer())
+                        .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
         when(buildingRequest.getRepositorySession()).thenReturn(repositorySession);
         when(session.getRepositorySession()).thenReturn(repositorySession);
 
@@ -194,8 +196,9 @@ public class DeployFileMojoTest extends AbstractMojoTestCase {
         when(buildingRequest.getRepositoryMerging()).thenReturn(ProjectBuildingRequest.RepositoryMerging.POM_DOMINANT);
         when(session.getProjectBuildingRequest()).thenReturn(buildingRequest);
         DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager(new SimpleLocalRepositoryManagerFactory()
-                .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
+        repositorySession.setLocalRepositoryManager(
+                new SimpleLocalRepositoryManagerFactory(new DefaultLocalPathComposer())
+                        .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
         when(buildingRequest.getRepositorySession()).thenReturn(repositorySession);
         when(session.getRepositorySession()).thenReturn(repositorySession);
 
@@ -248,8 +251,9 @@ public class DeployFileMojoTest extends AbstractMojoTestCase {
         when(buildingRequest.getRepositoryMerging()).thenReturn(ProjectBuildingRequest.RepositoryMerging.POM_DOMINANT);
         when(session.getProjectBuildingRequest()).thenReturn(buildingRequest);
         DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager(new SimpleLocalRepositoryManagerFactory()
-                .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
+        repositorySession.setLocalRepositoryManager(
+                new SimpleLocalRepositoryManagerFactory(new DefaultLocalPathComposer())
+                        .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
         when(buildingRequest.getRepositorySession()).thenReturn(repositorySession);
         when(session.getRepositorySession()).thenReturn(repositorySession);
 

--- a/src/test/java/org/apache/maven/plugins/deploy/DeployMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/deploy/DeployMojoTest.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.maven.execution.MavenSession;
@@ -37,11 +36,10 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
-import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.internal.impl.DefaultLocalPathComposer;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.RemoteRepository;
-import org.junit.Ignore;
 import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
 
@@ -75,10 +73,11 @@ public class DeployMojoTest extends AbstractMojoTestCase {
 
         session = mock(MavenSession.class);
         when(session.getPluginContext(any(PluginDescriptor.class), any(MavenProject.class)))
-                .thenReturn(new ConcurrentHashMap<String, Object>());
+                .thenReturn(new ConcurrentHashMap<>());
         DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager(new SimpleLocalRepositoryManagerFactory()
-                .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
+        repositorySession.setLocalRepositoryManager(
+                new SimpleLocalRepositoryManagerFactory(new DefaultLocalPathComposer())
+                        .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
         when(session.getRepositorySession()).thenReturn(repositorySession);
 
         remoteRepo = new File(REMOTE_REPO);
@@ -124,8 +123,9 @@ public class DeployMojoTest extends AbstractMojoTestCase {
         ProjectBuildingRequest buildingRequest = mock(ProjectBuildingRequest.class);
         when(session.getProjectBuildingRequest()).thenReturn(buildingRequest);
         DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager(new SimpleLocalRepositoryManagerFactory()
-                .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
+        repositorySession.setLocalRepositoryManager(
+                new SimpleLocalRepositoryManagerFactory(new DefaultLocalPathComposer())
+                        .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
         when(buildingRequest.getRepositorySession()).thenReturn(repositorySession);
         when(session.getRepositorySession()).thenReturn(repositorySession);
 
@@ -300,8 +300,9 @@ public class DeployMojoTest extends AbstractMojoTestCase {
         ProjectBuildingRequest buildingRequest = mock(ProjectBuildingRequest.class);
         when(session.getProjectBuildingRequest()).thenReturn(buildingRequest);
         DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager(new SimpleLocalRepositoryManagerFactory()
-                .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
+        repositorySession.setLocalRepositoryManager(
+                new SimpleLocalRepositoryManagerFactory(new DefaultLocalPathComposer())
+                        .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
         when(buildingRequest.getRepositorySession()).thenReturn(repositorySession);
         when(session.getRepositorySession()).thenReturn(repositorySession);
 
@@ -413,8 +414,9 @@ public class DeployMojoTest extends AbstractMojoTestCase {
         ProjectBuildingRequest buildingRequest = mock(ProjectBuildingRequest.class);
         when(session.getProjectBuildingRequest()).thenReturn(buildingRequest);
         DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager(new SimpleLocalRepositoryManagerFactory()
-                .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
+        repositorySession.setLocalRepositoryManager(
+                new SimpleLocalRepositoryManagerFactory(new DefaultLocalPathComposer())
+                        .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
         when(buildingRequest.getRepositorySession()).thenReturn(repositorySession);
         when(session.getRepositorySession()).thenReturn(repositorySession);
 
@@ -488,70 +490,6 @@ public class DeployMojoTest extends AbstractMojoTestCase {
         assertEquals(expectedFiles.size(), fileList.size());
 
         assertEquals(0, getSizeOfExpectedFiles(fileList, expectedFiles));
-    }
-
-    @Ignore("SCP is not part of Maven3 distribution. Aether handles transport extensions.")
-    public void _testBasicDeployWithScpAsProtocol() throws Exception {
-        String originalUserHome = System.getProperty("user.home");
-
-        // FIX THE DAMN user.home BEFORE YOU DELETE IT!!!
-        File altHome = new File(getBasedir(), "target/ssh-user-home");
-        altHome.mkdirs();
-
-        System.out.println("Testing user.home value for .ssh dir: " + altHome.getCanonicalPath());
-
-        Properties props = System.getProperties();
-        props.setProperty("user.home", altHome.getCanonicalPath());
-
-        System.setProperties(props);
-
-        File testPom = new File(getBasedir(), "target/test-classes/unit/basic-deploy-scp/plugin-config.xml");
-
-        mojo = (DeployMojo) lookupMojo("deploy", testPom);
-
-        assertNotNull(mojo);
-
-        RepositorySystem repositorySystem = mock(RepositorySystem.class);
-
-        setVariableValueToObject(mojo, "repositorySystem", repositorySystem);
-
-        File file = new File(
-                getBasedir(),
-                "target/test-classes/unit/basic-deploy-scp/target/" + "deploy-test-file-1.0-SNAPSHOT.jar");
-
-        assertTrue(file.exists());
-
-        MavenProject project = (MavenProject) getVariableValueFromObject(mojo, "project");
-
-        setVariableValueToObject(mojo, "pluginContext", new ConcurrentHashMap<>());
-        setVariableValueToObject(mojo, "reactorProjects", Collections.singletonList(project));
-
-        artifact = (DeployArtifactStub) project.getArtifact();
-
-        artifact.setFile(file);
-
-        String altUserHome = System.getProperty("user.home");
-
-        if (altUserHome.equals(originalUserHome)) {
-            // this is *very* bad!
-            throw new IllegalStateException(
-                    "Setting 'user.home' system property to alternate value did NOT work. Aborting test.");
-        }
-
-        File sshFile = new File(altUserHome, ".ssh");
-
-        System.out.println("Testing .ssh dir: " + sshFile.getCanonicalPath());
-
-        // delete first the .ssh folder if existing before executing the mojo
-        if (sshFile.exists()) {
-            FileUtils.deleteDirectory(sshFile);
-        }
-
-        mojo.execute();
-
-        assertTrue(sshFile.exists());
-
-        FileUtils.deleteDirectory(sshFile);
     }
 
     public void testLegacyAltDeploymentRepositoryWithDefaultLayout() throws Exception {


### PR DESCRIPTION
In general perform a cleanup of plugin, apply updates, where needed. The plugin now builds against latest 3.9.x and minimum is lifted to 3.6.3.

---

https://issues.apache.org/jira/browse/MDEPLOY-313