### PR TITLE
[MDEPLOY-320] Simplify and unify message

### DIFF
--- a/src/it/gav-validation/invoker.properties
+++ b/src/it/gav-validation/invoker.properties
@@ -18,5 +18,5 @@
 invoker.goals = org.apache.maven.plugins:maven-deploy-plugin:${project.version}:deploy-file
 invoker.buildResult = failure
 
-invoker.systemPropertiesFile.1 = test-invalid.properties
-invoker.systemPropertiesFile.2 = test-missing.properties
+invoker.userPropertiesFile.1 = test-invalid.properties
+invoker.userPropertiesFile.2 = test-missing.properties

--- a/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java
+++ b/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java
@@ -383,8 +383,6 @@ public class DeployMojo extends AbstractDeployMojo {
                     repo = getRemoteRepository(id, url);
                 } else {
                     throw new MojoExecutionException(
-                            altDeploymentRepo,
-                            "Invalid legacy syntax and layout for repository.",
                             "Invalid legacy syntax and layout for alternative repository. Use \"" + id + "::" + url
                                     + "\" instead, and only default layout is supported.");
                 }
@@ -392,10 +390,7 @@ public class DeployMojo extends AbstractDeployMojo {
                 matcher = ALT_REPO_SYNTAX_PATTERN.matcher(altDeploymentRepo);
 
                 if (!matcher.matches()) {
-                    throw new MojoExecutionException(
-                            altDeploymentRepo,
-                            "Invalid syntax for repository.",
-                            "Invalid syntax for alternative repository. Use \"id::url\".");
+                    throw new MojoExecutionException("Invalid syntax for alternative repository. Use \"id::url\".");
                 } else {
                     String id = matcher.group(1).trim();
                     String url = matcher.group(2).trim();

--- a/src/test/java/org/apache/maven/plugins/deploy/DeployMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/deploy/DeployMojoTest.java
@@ -718,9 +718,8 @@ public class DeployMojoTest extends AbstractMojoTestCase {
             mojo.getDeploymentRepository(project, null, null, "altDeploymentRepository::legacy::http://localhost");
             fail("Should throw: Invalid legacy syntax and layout for repository.");
         } catch (MojoExecutionException e) {
-            assertEquals(e.getMessage(), "Invalid legacy syntax and layout for repository.");
             assertEquals(
-                    e.getLongMessage(),
+                    e.getMessage(),
                     "Invalid legacy syntax and layout for alternative repository. Use \"altDeploymentRepository::http://localhost\" instead, and only default layout is supported.");
         }
     }
@@ -739,9 +738,8 @@ public class DeployMojoTest extends AbstractMojoTestCase {
                     project, null, null, "altDeploymentRepository::hey::wow::foo::http://localhost");
             fail("Should throw: Invalid legacy syntax and layout for repository.");
         } catch (MojoExecutionException e) {
-            assertEquals(e.getMessage(), "Invalid legacy syntax and layout for repository.");
             assertEquals(
-                    e.getLongMessage(),
+                    e.getMessage(),
                     "Invalid legacy syntax and layout for alternative repository. Use \"altDeploymentRepository::wow::foo::http://localhost\" instead, and only default layout is supported.");
         }
     }
@@ -775,9 +773,8 @@ public class DeployMojoTest extends AbstractMojoTestCase {
                     project, null, null, "altDeploymentRepository::legacy::scm:svn:http://localhost");
             fail("Should throw: Invalid legacy syntax and layout for repository.");
         } catch (MojoExecutionException e) {
-            assertEquals(e.getMessage(), "Invalid legacy syntax and layout for repository.");
             assertEquals(
-                    e.getLongMessage(),
+                    e.getMessage(),
                     "Invalid legacy syntax and layout for alternative repository. Use \"altDeploymentRepository::scm:svn:http://localhost\" instead, and only default layout is supported.");
         }
     }


### PR DESCRIPTION
This plugin used old ctor for MojoExecutionException that uses "message", "long message" and "source". The source is fully unused in Maven Core, while long message just complicates things.

Just unify message, use one "standard" exception message.

---

https://issues.apache.org/jira/browse/MDEPLOY-320