### PR TITLE
Improve error message readability with line breaks

### DIFF
--- a/src/main/java/org/apache/maven/plugins/deploy/AbstractDeployMojo.java
+++ b/src/main/java/org/apache/maven/plugins/deploy/AbstractDeployMojo.java
@@ -99,4 +99,39 @@ public abstract class AbstractDeployMojo implements Mojo {
     protected Log getLog() {
         return logger;
     }
+
+    /**
+     * Formats error messages by adding line breaks for better readability.
+     * This method handles common error message patterns used throughout the plugin.
+     *
+     * @param message the original error message
+     * @return the formatted error message with line breaks
+     */
+    protected String formatErrorMessage(String message) {
+        if (message == null) {
+            return null;
+        }
+        // Add line breaks at key points for better readability
+        return message.replace("Failed to deploy artifacts: ", "Failed to deploy artifacts:\n    ")
+                .replace("): ", "):\n    ")
+                .replace("Deployment failed: ", "Deployment failed:\n    ")
+                .replace(". Use ", ".\n    Use ")
+                .replace(
+                        "Invalid legacy syntax and layout for alternative repository: ",
+                        "Invalid legacy syntax and layout for alternative repository: ")
+                .replace("Invalid syntax for alternative repository: ", "Invalid syntax for alternative repository: ");
+    }
+
+    /**
+     * Formats a two-part error message where both parts should appear on separate new lines.
+     * This is useful for error messages that have an explanation followed by usage instructions.
+     * The returned message starts with a newline so the first part appears on its own line.
+     *
+     * @param part1 the first part of the error message (will be on line 1)
+     * @param part2 the second part of the error message (will be on line 2 with indentation)
+     * @return the formatted error message with line breaks
+     */
+    protected String formatTwoPartErrorMessage(String part1, String part2) {
+        return "\n    " + part1 + "\n    " + part2;
+    }
 }

--- a/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java
+++ b/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java
@@ -337,19 +337,19 @@ public class DeployMojo extends AbstractDeployMojo {
                             + "\" instead.");
                     repo = createDeploymentArtifactRepository(id, url);
                 } else {
-                    String errorMsg = formatTwoPartErrorMessage(
+                    String longMessage = formatTwoPartErrorMessage(
                             "Invalid legacy syntax and layout for alternative repository: \"" + id + "::" + url + "\".",
                             "Use \"" + id + "::" + url + "\" instead, and only default layout is supported.");
-                    throw new MojoException(errorMsg);
+                    throw new MojoException(this, "Invalid legacy syntax and layout for repository.", longMessage);
                 }
             } else {
                 matcher = ALT_REPO_SYNTAX_PATTERN.matcher(altDeploymentRepo);
 
                 if (!matcher.matches()) {
-                    String errorMsg = formatTwoPartErrorMessage(
+                    String longMessage = formatTwoPartErrorMessage(
                             "Invalid syntax for alternative repository: \"" + altDeploymentRepo + "\".",
                             "Use \"id::url\".");
-                    throw new MojoException(errorMsg);
+                    throw new MojoException(this, "Invalid syntax for alternative repository.", longMessage);
                 } else {
                     String id = matcher.group(1).trim();
                     String url = matcher.group(2).trim();

--- a/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java
+++ b/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java
@@ -53,7 +53,6 @@ import org.apache.maven.api.services.ProjectManager;
 @Mojo(name = "deploy", defaultPhase = "deploy")
 public class DeployMojo extends AbstractDeployMojo {
     private static final Pattern ALT_LEGACY_REPO_SYNTAX_PATTERN = Pattern.compile("(.+?)::(.+?)::(.+)");
-
     private static final Pattern ALT_REPO_SYNTAX_PATTERN = Pattern.compile("(.+?)::(.+)");
 
     @Inject
@@ -254,7 +253,10 @@ public class DeployMojo extends AbstractDeployMojo {
         } catch (MojoException e) {
             throw e;
         } catch (Exception e) {
-            throw new MojoException(e.getMessage(), e);
+            // Log the full stack trace at debug level
+            getLog().debug(e);
+            // Throw with formatted message but without cause to avoid duplicate output
+            throw new MojoException(formatErrorMessage(e.getMessage()));
         }
     }
 
@@ -335,20 +337,19 @@ public class DeployMojo extends AbstractDeployMojo {
                             + "\" instead.");
                     repo = createDeploymentArtifactRepository(id, url);
                 } else {
-                    throw new MojoException(
-                            altDeploymentRepo,
-                            "Invalid legacy syntax and layout for repository.",
-                            "Invalid legacy syntax and layout for alternative repository. Use \"" + id + "::" + url
-                                    + "\" instead, and only default layout is supported.");
+                    String errorMsg = formatTwoPartErrorMessage(
+                            "Invalid legacy syntax and layout for alternative repository: \"" + id + "::" + url + "\".",
+                            "Use \"" + id + "::" + url + "\" instead, and only default layout is supported.");
+                    throw new MojoException(errorMsg);
                 }
             } else {
                 matcher = ALT_REPO_SYNTAX_PATTERN.matcher(altDeploymentRepo);
 
                 if (!matcher.matches()) {
-                    throw new MojoException(
-                            altDeploymentRepo,
-                            "Invalid syntax for repository.",
-                            "Invalid syntax for alternative repository. Use \"id::url\".");
+                    String errorMsg = formatTwoPartErrorMessage(
+                            "Invalid syntax for alternative repository: \"" + altDeploymentRepo + "\".",
+                            "Use \"id::url\".");
+                    throw new MojoException(errorMsg);
                 } else {
                     String id = matcher.group(1).trim();
                     String url = matcher.group(2).trim();
@@ -375,10 +376,9 @@ public class DeployMojo extends AbstractDeployMojo {
         }
 
         if (repo == null) {
-            String msg = "Deployment failed: repository element was not specified in the POM inside"
-                    + " distributionManagement element or in -DaltDeploymentRepository=id::url parameter";
-
-            throw new MojoException(msg);
+            throw new MojoException(
+                    formatErrorMessage("Deployment failed: repository element was not specified in the POM inside"
+                            + " distributionManagement element or in -DaltDeploymentRepository=id::url parameter"));
         }
 
         return repo;

--- a/src/test/java/org/apache/maven/plugins/deploy/DeployMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/deploy/DeployMojoTest.java
@@ -201,7 +201,8 @@ class DeployMojoTest {
                 "Should throw: Invalid legacy syntax and layout for repository.");
         assertEquals("Invalid legacy syntax and layout for repository.", e.getMessage());
         assertEquals(
-                "Invalid legacy syntax and layout for alternative repository. Use \"altDeploymentRepository::http://localhost\" instead, and only default layout is supported.",
+                "\n    Invalid legacy syntax and layout for alternative repository: \"altDeploymentRepository::http://localhost\".\n    "
+                        + "Use \"altDeploymentRepository::http://localhost\" instead, and only default layout is supported.",
                 e.getLongMessage());
     }
 
@@ -217,7 +218,8 @@ class DeployMojoTest {
                 "Should throw: Invalid legacy syntax and layout for repository.");
         assertEquals("Invalid legacy syntax and layout for repository.", e.getMessage());
         assertEquals(
-                "Invalid legacy syntax and layout for alternative repository. Use \"altDeploymentRepository::wow::foo::http://localhost\" instead, and only default layout is supported.",
+                "\n    Invalid legacy syntax and layout for alternative repository: \"altDeploymentRepository::wow::foo::http://localhost\".\n    "
+                        + "Use \"altDeploymentRepository::wow::foo::http://localhost\" instead, and only default layout is supported.",
                 e.getLongMessage());
     }
 
@@ -244,7 +246,8 @@ class DeployMojoTest {
                 "Should throw: Invalid legacy syntax and layout for repository.");
         assertEquals("Invalid legacy syntax and layout for repository.", e.getMessage());
         assertEquals(
-                "Invalid legacy syntax and layout for alternative repository. Use \"altDeploymentRepository::scm:svn:http://localhost\" instead, and only default layout is supported.",
+                "\n    Invalid legacy syntax and layout for alternative repository: \"altDeploymentRepository::scm:svn:http://localhost\".\n    "
+                        + "Use \"altDeploymentRepository::scm:svn:http://localhost\" instead, and only default layout is supported.",
                 e.getLongMessage());
     }
 


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

 Improve Error Message Readability with Line Breaks                                                                                                  
                                                                                                                                                      
  Purpose                                                                                                                                             
                                                                                                                                                    
  This pull request enhances the readability of error messages produced by the Maven Deploy Plugin by adding strategic line breaks to long error      
  messages. The changes make it easier for developers to quickly understand deployment failures and their solutions.                                  

  Motivation

  Long error messages in the Maven Deploy Plugin were previously displayed as continuous text that wrapped at awkward positions, making it difficult
  to:
  - Quickly identify the root cause of deployment failures
  - Distinguish between error descriptions and usage instructions
  - Parse status codes and repository URLs in transfer errors

  Before (hard to read):

  [ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:3.1.3-SNAPSHOT:deploy (default-deploy) on project devcloudsdks: Invalid
  legacy syntax and layout for alternative repository: "releases::default111::https://nexus.mingyuanyun.com/repository/maven-releases". Use
  "releases::https://nexus.mingyuanyun.com/repository/maven-releases" instead, and only default layout is supported.

<img width="1341" height="285" alt="Image" src="https://github.com/user-attachments/assets/26e4fc2b-2437-48fb-8686-b7fbb393fd3c" />

<img width="1609" height="801" alt="Image" src="https://github.com/user-attachments/assets/7bfde612-84f6-4f06-8c53-b43d4250f096" />

  After (clear structure):

  [ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:3.1.3-SNAPSHOT:deploy (default-deploy) on project devcloudsdks:
  [ERROR]     Invalid legacy syntax and layout for alternative repository:
  "releases::default111::https://nexus.mingyuanyun.com/repository/maven-releases".
  [ERROR]     Use "releases::https://nexus.mingyuanyun.com/repository/maven-releases" instead, and only default layout is supported.

<img width="1316" height="360" alt="Image" src="https://github.com/user-attachments/assets/9f10bc72-05ca-4244-982f-c924696ff37a" />

or

<img width="1313" height="361" alt="Image" src="https://github.com/user-attachments/assets/d42f1ac5-bf2a-4f8f-9c05-8cbc52b30ea6" />

  Testing

  The changes have been tested with the following scenarios:
  - Invalid legacy syntax errors (altDeploymentRepository with wrong format)
  - Deployment transfer failures
  - Missing repository configuration errors

  Compatibility

  - Backward Compatible: Yes - only changes message formatting, no API changes
  - Maven Versions: Works with both Maven 3.x and Maven 4.x
  - Branches:
    - master branch (Maven 4, version 4.0.0-beta-3-SNAPSHOT)
    - maven-deploy-plugin-3.x branch (Maven 3, version 3.1.3-SNAPSHOT)

  Benefits

  1. Faster debugging: Developers can quickly scan error messages
  2. Better IDE integration: Line breaks align with Maven's error output format
  3. Consistent formatting: All error messages follow the same pattern
  4. Maintainable: Centralized formatting logic makes future changes easy
