### PR TITLE
enable build with Maven 4

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,7 +25,6 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
-# still fails
-#    with:
-#      maven4-enabled: true
+    with:
+      maven4-enabled: true
 

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,7 +25,5 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
-# still fails
-#    with:
-#      maven4-enabled: true
-
+    with:
+      maven4-enabled: true

--- a/src/it/deploy-attached-sources/test.properties
+++ b/src/it/deploy-attached-sources/test.properties
@@ -16,10 +16,10 @@
 # under the License.
 
 # Properties passed to invocations of the deploy plugin
-pomFile = ${basedir}/pom.xml
+pomFile = pom.xml
 
-file = ${basedir}/target/${project.artifactId}-${project.version}.jar
-sources = ${basedir}/target/${project.artifactId}-${project.version}-sources.jar
-javadoc = ${basedir}/target/${project.artifactId}-${project.version}-javadoc.jar
+file = target/test-1.0-SNAPSHOT.jar
+sources = target/test-1.0-SNAPSHOT-sources.jar
+javadoc = target/test-1.0-SNAPSHOT-javadoc.jar
 
-url = file://${basedir}/target/repo
+url=file:./target/repo

--- a/src/it/deploy-default-packaging/test.properties
+++ b/src/it/deploy-default-packaging/test.properties
@@ -19,5 +19,5 @@
 groupId = org.apache.maven.test
 artifactId = test
 version = 1.1
-file = ${basedir}/lib/test-1.1.jar
-url = file://${basedir}/target/repo
+file = lib/test-1.1.jar
+url = file:./target/repo


### PR DESCRIPTION
build with Maven 4 in CI, to check if maven-deploy-plugin 3.x works with Maven 4

and complete the table on https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=406620656#Maven4.0.0GAchecklist-Maven4API

