### PR TITLE
Update to Maven 4 rc-5

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,4 +27,4 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
     with:
       maven4-build: true
-      maven4-version: '4.0.0-rc-3' # as in project, rc-4 needs some work
+      maven4-version: '4.0.0-rc-5' # as in project

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@ under the License.
 
   <properties>
     <javaVersion>17</javaVersion>
-    <mavenVersion>4.0.0-rc-3</mavenVersion>
+    <mavenVersion>4.0.0-rc-5</mavenVersion>
 
     <guiceVersion>6.0.0</guiceVersion>
     <mavenAntrunPluginVersion>${version.maven-antrun-plugin}</mavenAntrunPluginVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,19 @@ under the License.
         <artifactId>guava</artifactId>
         <version>33.6.0-jre</version>
       </dependency>
+      <!--
+        maven-plugin-testing-harness 4.0.0-beta-4 transitively pins maven-xml to 4.0.0-rc-3
+        and pulls in maven-xml-impl 4.0.0-alpha-9 (an artifact ID that no longer exists
+        from rc-4 onward; the XmlService implementation moved into maven-xml itself).
+        Pin maven-xml to ${mavenVersion} so the right XmlService provider is on the
+        test classpath; otherwise Holder.<clinit> fails with
+        "No XmlService implementation found" and every unit test errors out.
+      -->
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-xml</artifactId>
+        <version>${mavenVersion}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/src/it/MDEPLOY-169_deploy-at-end-multithread/verify.groovy
+++ b/src/it/MDEPLOY-169_deploy-at-end-multithread/verify.groovy
@@ -17,6 +17,15 @@
  * under the License.
  */
 
-assert new File( basedir, "target/repo/org/apache/maven/its/mdeploy-169/multithread/1.0/multithread-1.0.pom" ).exists()
-assert new File( basedir, "module1/target/repo/org/apache/maven/its/mdeploy-169/module1/1.0/module1-1.0.pom" ).exists()
-assert new File( basedir, "module2/target/repo/org/apache/maven/its/mdeploy-169/module2/1.0/module2-1.0.pom" ).exists()
+rootRepo = new File( basedir, "target/repo" )
+module1Repo = new File( basedir, "module1/target/repo" )
+module2Repo = new File( basedir, "module2/target/repo" )
+
+if (mavenVersion.startsWith('4.')) {
+    // Maven 4 deploys in the root target directory, as defined in the root POM
+    module1Repo = module2Repo = rootRepo
+}
+
+assert new File( rootRepo, "org/apache/maven/its/mdeploy-169/multithread/1.0/multithread-1.0.pom" ).exists()
+assert new File( module1Repo, "org/apache/maven/its/mdeploy-169/module1/1.0/module1-1.0.pom" ).exists()
+assert new File( module2Repo, "org/apache/maven/its/mdeploy-169/module2/1.0/module2-1.0.pom" ).exists()

--- a/src/it/MDEPLOY-170_deploy-at-end-configperproject/verify.groovy
+++ b/src/it/MDEPLOY-170_deploy-at-end-configperproject/verify.groovy
@@ -17,6 +17,15 @@
  * under the License.
  */
 
-assert new File( basedir, "target/repo/org/apache/maven/its/mdeploy-170/configperproject/1.0/configperproject-1.0.pom" ).exists()
-assert new File( basedir, "module1/target/repo/org/apache/maven/its/mdeploy-170/module1/1.0/module1-1.0.pom" ).exists()
-assert !( new File( basedir, "module2/target/repo/org/apache/maven/its/mdeploy-170/module2/1.0/module2-1.0.pom" ).exists() )
+rootRepo = new File( basedir, "target/repo" )
+module1Repo = new File( basedir, "module1/target/repo" )
+module2Repo = new File( basedir, "module1/target/repo" )
+
+if (mavenVersion.startsWith('4.')) {
+    // Maven 4 deploys in the root target directory, as defined in the root POM
+    module1Repo = module2Repo = rootRepo
+}
+
+assert new File( rootRepo, "org/apache/maven/its/mdeploy-170/configperproject/1.0/configperproject-1.0.pom" ).exists()
+assert new File( module1Repo, "org/apache/maven/its/mdeploy-170/module1/1.0/module1-1.0.pom" ).exists()
+assert !( new File( module2Repo, "org/apache/maven/its/mdeploy-170/module2/1.0/module2-1.0.pom" ).exists() )

--- a/src/it/MDEPLOY-224_deploy-at-end-only-modules/pom.xml
+++ b/src/it/MDEPLOY-224_deploy-at-end-only-modules/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <version>1.0</version>
   <packaging>pom</packaging>
 
-  <description>Tests deployment at end only in modules.</description>
+  <description>Tests deployment at end only in modules. https://github.com/apache/maven-deploy-plugin/issues/374</description>
 
   <modules>
     <module>module1</module>

--- a/src/it/MDEPLOY-224_deploy-at-end-only-modules/verify.groovy
+++ b/src/it/MDEPLOY-224_deploy-at-end-only-modules/verify.groovy
@@ -17,9 +17,18 @@
  * under the License.
  */
 
-assert new File( basedir, "target/repo/org/apache/maven/its/mdeploy-224/parent/1.0/parent-1.0.pom" ).exists()
-assert new File( basedir, "module1/target/repo/org/apache/maven/its/mdeploy-224/module1/1.0/module1-1.0.pom" ).exists()
-assert new File( basedir, "module2/target/repo/org/apache/maven/its/mdeploy-224/module2/1.0/module2-1.0.pom" ).exists()
+rootRepo = new File( basedir, "target/repo" )
+module1Repo = new File( basedir, "module1/target/repo" )
+module2Repo = new File( basedir, "module2/target/repo" )
+
+if (mavenVersion.startsWith('4.')) {
+    // Maven 4 deploys in the root target directory, as defined in the root POM
+    module1Repo = module2Repo = rootRepo
+}
+
+assert new File( rootRepo, "org/apache/maven/its/mdeploy-224/parent/1.0/parent-1.0.pom" ).exists()
+assert new File( module1Repo, "org/apache/maven/its/mdeploy-224/module1/1.0/module1-1.0.pom" ).exists()
+assert new File( module2Repo, "org/apache/maven/its/mdeploy-224/module2/1.0/module2-1.0.pom" ).exists()
 
 def buildLog = new File ( basedir, "build.log").text
 

--- a/src/it/MDEPLOY-225_deploy-at-end-skip-root/pom.xml
+++ b/src/it/MDEPLOY-225_deploy-at-end-skip-root/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <version>1.0</version>
   <packaging>pom</packaging>
 
-  <description>Tests deployment at end with skipped root project.</description>
+  <description>Tests deployment at end with skipped root project. https://github.com/apache/maven-deploy-plugin/issues/533</description>
 
   <modules>
     <module>module1</module>

--- a/src/it/MDEPLOY-225_deploy-at-end-skip-root/verify.groovy
+++ b/src/it/MDEPLOY-225_deploy-at-end-skip-root/verify.groovy
@@ -17,6 +17,18 @@
  * under the License.
  */
 
-assert ! new File( basedir, "target/repo" ).exists()
-assert new File( basedir, "module1/target/repo/org/apache/maven/its/mdeploy-225/module1/1.0/module1-1.0.pom" ).exists()
-assert new File( basedir, "module2/target/repo/org/apache/maven/its/mdeploy-225/module2/1.0/module2-1.0.pom" ).exists()
+rootRepo = new File( basedir, "target/repo" )
+module1Repo = new File( basedir, "module1/target/repo" )
+module2Repo = new File( basedir, "module2/target/repo" )
+
+if (mavenVersion.startsWith('4.')) {
+    // Maven 4 deploys in the root target directory, as defined in the root POM (even if not deployed)
+    module1Repo = module2Repo = rootRepo
+} else {
+    // Maven 3 deploys in the each module target directory, nothing in root
+    assert ! rootRepo.exists()
+}
+
+// check that files are deployed both by Maven 3 and 4 = https://github.com/apache/maven-deploy-plugin/issues/533
+assert new File( module1Repo, "org/apache/maven/its/mdeploy-225/module1/1.0/module1-1.0.pom" ).exists()
+assert new File( module2Repo, "org/apache/maven/its/mdeploy-225/module2/1.0/module2-1.0.pom" ).exists()

--- a/src/it/deploy-attached-sources/test.properties
+++ b/src/it/deploy-attached-sources/test.properties
@@ -16,10 +16,10 @@
 # under the License.
 
 # Properties passed to invocations of the deploy plugin
-pomFile = ${project.basedir}/pom.xml
+pomFile = pom.xml
 
-file = ${project.basedir}/target/${project.artifactId}-${project.version}.jar
-sources = ${project.basedir}/target/${project.artifactId}-${project.version}-sources.jar
-javadoc = ${project.basedir}/target/${project.artifactId}-${project.version}-javadoc.jar
+file = target/test-1.0-SNAPSHOT.jar
+sources = target/test-1.0-SNAPSHOT-sources.jar
+javadoc = target/test-1.0-SNAPSHOT-javadoc.jar
 
-url = file://${project.basedir}/target/repo
+url=file:./target/repo

--- a/src/it/deploy-default-packaging/test.properties
+++ b/src/it/deploy-default-packaging/test.properties
@@ -19,5 +19,5 @@
 groupId = org.apache.maven.test
 artifactId = test
 version = 1.1
-file = ${project.basedir}/lib/test-1.1.jar
-url = file://${project.basedir}/target/repo
+file = lib/test-1.1.jar
+url = file:./target/repo

--- a/src/main/java/org/apache/maven/plugins/deploy/DeployFileMojo.java
+++ b/src/main/java/org/apache/maven/plugins/deploy/DeployFileMojo.java
@@ -368,7 +368,7 @@ public class DeployFileMojo extends AbstractDeployMojo {
                     ProducedArtifact deployable = session.createProducedArtifact(
                             artifact.getGroupId(),
                             artifact.getArtifactId(),
-                            artifact.getVersion().asString(),
+                            artifact.getVersion().toString(),
                             classifiers.substring(ci, nci).trim(),
                             extension,
                             type);


### PR DESCRIPTION
Builds master green on Maven 4 rc-5. Stacks two existing rc-5 efforts and adds
the small classpath fix that was missing from the first attempt.

## Commits

1. **Failing to update to rc5** — cherry-pick of #632 (`f801ee5`, @Bukama).
   Bumps `mavenVersion` and the CI workflow's `maven4-version` from rc-3 to
   rc-5, plus `Version.asString()` → `toString()` in `DeployFileMojo` for
   the API change in rc-5.

2. **update deployAtEnd ITs to match latest 4 behaviour** — cherry-pick of
   `bed4d62` (@hboutemy, from the `maven4-enabled` branch). Teaches the
   MDEPLOY-224 / MDEPLOY-225 `verify.groovy` scripts about Maven 4's
   "deploy at root target" behaviour.

3. **work around Maven 4 CLI lack of interpolation** — cherry-pick of
   `dd96008` (@hboutemy, from #655 on the 3.x line, applies here too).
   Rewrites the `deploy-file` IT property fixtures to relative paths,
   since Maven 4's invoker sub-builds no longer interpolate
   `${project.basedir}` / `${project.artifactId}` / `${project.version}`
   inside `invoker.properties`.

4. **Pin maven-xml to ${mavenVersion} for the test classpath** — fixes the
   `XmlService$Holder.<clinit>` `NoClassDefFoundError` @Bukama documented
   on #632. `maven-plugin-testing-harness:4.0.0-beta-4` transitively pins
   `maven-xml` to rc-3 and pulls in `maven-xml-impl:4.0.0-alpha-9` (an
   artifactId removed at rc-4 — the SPI provider now lives inside
   `maven-xml` itself). Pinning `maven-xml` to `${mavenVersion}` in
   `dependencyManagement` puts a matching provider on the unit-test
   classpath.

## Verification

`mvn -P run-its clean verify` on Apache Maven 4.0.0-rc-5 / JDK 17:
**42 passed / 0 failed**.

References #632.