### PR TITLE
Build against Maven 4.0.0-rc-6

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,4 +27,4 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
       maven4-build: true
-      maven4-version: '4.0.0-rc-5' # as in project
+      maven4-version: '4.0.0-rc-6' # as in project

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@ under the License.
 
   <properties>
     <javaVersion>17</javaVersion>
-    <mavenVersion>4.0.0-rc-5</mavenVersion>
+    <mavenVersion>4.0.0-rc-6</mavenVersion>
 
     <guiceVersion>7.0.0</guiceVersion>
     <mavenAntrunPluginVersion>${version.maven-antrun-plugin}</mavenAntrunPluginVersion>


### PR DESCRIPTION
4.0.0-rc-6 is released. This moves the Maven 4 version property to it and pins the same version explicitly in the Verify workflow, so CI no longer depends on the `maven4-version` default in maven-gh-actions-shared.

Verified: green on the fork before opening (`Verify` workflow, full matrix).
