### PR TITLE
Drop backslash escapes that Markdown does not need

### DIFF
--- a/src/site/markdown/examples/deploy-ftp.md
+++ b/src/site/markdown/examples/deploy-ftp.md
@@ -66,7 +66,7 @@ Your `settings.xml` would contain a `server` element where the `id` of that elem
 </settings>
 ```
 
-You should, of course, make sure that you can login into the specified FTP server by hand before attempting the deployment with Maven\. Once you have verified that everything is setup correctly you can now deploy your artifacts using Maven:
+You should, of course, make sure that you can login into the specified FTP server by hand before attempting the deployment with Maven. Once you have verified that everything is setup correctly you can now deploy your artifacts using Maven:
 
 ```unknown
 mvn deploy

--- a/src/site/markdown/examples/deploy-network-issues.md
+++ b/src/site/markdown/examples/deploy-network-issues.md
@@ -24,9 +24,9 @@ date: 2019-01-20
 
 # Deploying With Network Issues
 
-Sometimes, network quality from building machine to the remote repository is not perfect\. Of course, improving the network would be the best solution, but it is not always possible\.
+Sometimes, network quality from building machine to the remote repository is not perfect. Of course, improving the network would be the best solution, but it is not always possible.
 
-There are a few strategies to work around the network issue\.
+There are a few strategies to work around the network issue.
 
 ## Configuring Multiple Tries
 
@@ -56,7 +56,7 @@ When the network is really not consistent, a deeper strategy is to deploy in 2 s
 
 1\. `deploy` to a local directory during the build, for example `file:./target/staging-deploy`,
 
-2\. then copy from the local area to the target remote repository, retrying as much as necessary\.
+2\. then copy from the local area to the target remote repository, retrying as much as necessary.
 
 ### Deploying to a Local Directory
 
@@ -66,21 +66,21 @@ Deploying to a local directory can be done from command line, without changing P
 mvn deploy -DaltDeploymentRepository=local::file:./target/staging-deploy
 ```
 
-or for older 2\.x version of maven\-deploy\-plugin
+or for older 2\.x version of maven-deploy-plugin
 
 ```unknown
 mvn deploy -DaltDeploymentRepository=local::default::file:./target/staging-deploy
 ```
 
-Of course, you can configure the repository in your `pom.xml` if you want to go from a temporary strategy to the general strategy\.
+Of course, you can configure the repository in your `pom.xml` if you want to go from a temporary strategy to the general strategy.
 
 ### Copying from Local Directory to Target Remote Repository
 
-`wagon-maven-plugin`&apos;s [`merge-maven-repos` goal](https://www.mojohaus.org/wagon-maven-plugin/merge-maven-repos-mojo.html) provides a mechanism to copy from one remote repository to the other, while merging repository metadata\.
+`wagon-maven-plugin`&apos;s [`merge-maven-repos` goal](https://www.mojohaus.org/wagon-maven-plugin/merge-maven-repos-mojo.html) provides a mechanism to copy from one remote repository to the other, while merging repository metadata.
 
-`wagon-maven-plugin`&apos;s [`upload` goal](https://www.mojohaus.org/wagon-maven-plugin/upload-mojo.html) will do the same without taking care of repository metadata: use it if you have an empty repository as target, like a staging repository provided by a repository manager\.
+`wagon-maven-plugin`&apos;s [`upload` goal](https://www.mojohaus.org/wagon-maven-plugin/upload-mojo.html) will do the same without taking care of repository metadata: use it if you have an empty repository as target, like a staging repository provided by a repository manager.
 
-It can be invoked fully from command line \(renaming `-Dwagon.` with `wagon.targetId` when [Wagon Maven Plugin 2\.0\.1 will be released](https://github.com/mojohaus/wagon-maven-plugin/pull/26)\):
+It can be invoked fully from command line (renaming `-Dwagon.` with `wagon.targetId` when [Wagon Maven Plugin 2\.0\.1 will be released](https://github.com/mojohaus/wagon-maven-plugin/pull/26)):
 
 ```unknown
 mvn org.codehaus.mojo:wagon-maven-plugin:2.0.0:merge-maven-repos \

--- a/src/site/markdown/examples/deploy-ssh-external.md
+++ b/src/site/markdown/examples/deploy-ssh-external.md
@@ -51,7 +51,7 @@ In order to deploy artifacts using SSH you must first specify the use of an SSH 
 </project>
 ```
 
-If you are deploying from Unix or have Cygwin installed you won&apos;t need to any additional configuration in your `settings.xml` file as everything will be taken from the environment\. But if you are on Windows and are using something like `plink` then you will need something like the following:
+If you are deploying from Unix or have Cygwin installed you won&apos;t need to any additional configuration in your `settings.xml` file as everything will be taken from the environment. But if you are on Windows and are using something like `plink` then you will need something like the following:
 
 ```unknown
 
@@ -73,7 +73,7 @@ If you are deploying from Unix or have Cygwin installed you won&apos;t need to a
 </settings>
 ```
 
-You should, of course, make sure that you can login into the specified SSH server by hand before attempting the deployment with Maven\. Once you have verified that everything is setup correctly you can now deploy your artifacts using Maven:
+You should, of course, make sure that you can login into the specified SSH server by hand before attempting the deployment with Maven. Once you have verified that everything is setup correctly you can now deploy your artifacts using Maven:
 
 ```unknown
 mvn deploy
@@ -105,5 +105,5 @@ Sometimes you may have permissions problems deploying and if so you can set the 
  </settings>
 ```
 
-**NOTE:** If you are using Putty it will expect the private key to be in the `PPK` format and not the standard format so make sure you use `puttygen` to convert your openssh format key to `PPK` format or generate another one\. Windows users can find the Putty tools on the [PuTTY Download Page](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html)\.
+**NOTE:** If you are using Putty it will expect the private key to be in the `PPK` format and not the standard format so make sure you use `puttygen` to convert your openssh format key to `PPK` format or generate another one. Windows users can find the Putty tools on the [PuTTY Download Page](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html).
 

--- a/src/site/markdown/examples/deploying-in-legacy-layout.md.vm
+++ b/src/site/markdown/examples/deploying-in-legacy-layout.md.vm
@@ -24,7 +24,7 @@ date: 2006-06-21
 
 # Deploy an artifact in legacy layout
 
-&quot;Legacy&quot; is the layout used in maven 1 repositories while maven 2 uses &quot;default&quot;\. They are different in terms of directory structure, timestamp of snapshots in default and existence of metadata files in default\.
+&quot;Legacy&quot; is the layout used in maven 1 repositories while maven 2 uses &quot;default&quot;. They are different in terms of directory structure, timestamp of snapshots in default and existence of metadata files in default.
 
 - legacy layout directory structure:
 
@@ -45,7 +45,7 @@ date: 2006-06-21
          |---metadata
     ```
 
-    In able to deploy an artifact in a legacy layout of repository, set the **repositoryLayout** parameter to `legacy` value\.
+    In able to deploy an artifact in a legacy layout of repository, set the **repositoryLayout** parameter to `legacy` value.
 
     ```unknown
     mvn ${project.groupId}:${project.artifactId}:${project.version}:deploy-file -Durl=file:///C:/m2-repo \
@@ -55,5 +55,5 @@ date: 2006-06-21
                                                                                 -DrepositoryLayout=legacy
     ```
 
-    **Note**: By using the fully qualified path of a goal, you&apos;re ensured to be using the preferred version of the maven\-deploy\-plugin\. When using `mvn deploy:deploy-file` its version depends on its specification in the pom or the version of Apache Maven\.
+    **Note**: By using the fully qualified path of a goal, you&apos;re ensured to be using the preferred version of the maven-deploy-plugin. When using `mvn deploy:deploy-file` its version depends on its specification in the pom or the version of Apache Maven.
 

--- a/src/site/markdown/examples/deploying-sources-javadoc.md.vm
+++ b/src/site/markdown/examples/deploying-sources-javadoc.md.vm
@@ -22,7 +22,7 @@ date: 20011-02-23
 
 # Deploy sources and javadoc jars
 
-A project may include a main jar and associated sources and javadoc jars\.
+A project may include a main jar and associated sources and javadoc jars.
 
 ```unknown
   artifact-name-1.0.jar
@@ -30,7 +30,7 @@ A project may include a main jar and associated sources and javadoc jars\.
   artifact-name-1.0-javadoc.jar
 ```
 
-The sources jar contains the Java sources, and the javadoc jar contains the generated javadocs\. To include these files in your deployment, set the **sources** and **javadoc** parameters to the paths to the sources and javadoc jar files\.
+The sources jar contains the Java sources, and the javadoc jar contains the generated javadocs. To include these files in your deployment, set the **sources** and **javadoc** parameters to the paths to the sources and javadoc jar files.
 
 ```unknown
 mvn ${project.groupId}:${project.artifactId}:${project.version}:deploy-file -Durl=file:///home/me/m2-repo \
@@ -41,5 +41,5 @@ mvn ${project.groupId}:${project.artifactId}:${project.version}:deploy-file -Dur
                                                                             -Djavadoc=./path/to/artifact-name-1.0-javadoc.jar
 ```
 
-**Note**: By using the fully qualified path of a goal, you&apos;re ensured to be using the preferred version of the maven\-deploy\-plugin\. When using `mvn deploy:deploy-file` its version depends on its specification in the pom or the version of Apache Maven\.
+**Note**: By using the fully qualified path of a goal, you&apos;re ensured to be using the preferred version of the maven-deploy-plugin. When using `mvn deploy:deploy-file` its version depends on its specification in the pom or the version of Apache Maven.
 

--- a/src/site/markdown/examples/deploying-with-classifiers.md.vm
+++ b/src/site/markdown/examples/deploying-with-classifiers.md.vm
@@ -24,15 +24,15 @@ date: 2013-09-01
 
 # Deploy an artifact with classifier
 
-Beside the main artifact there can be additional files which are attached to the Maven project\. Such attached files can be recognized and accessed by their classifier\.
+Beside the main artifact there can be additional files which are attached to the Maven project. Such attached files can be recognized and accessed by their classifier.
 
-For example: from the following artifact names, the classifier is located between the version and extension name of the artifact\.
+For example: from the following artifact names, the classifier is located between the version and extension name of the artifact.
 
-- `artifact-name-1.0.jar` the main jar which contains classes compiled without [debugging](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#debug) information \(such as linenumbers\)
+- `artifact-name-1.0.jar` the main jar which contains classes compiled without [debugging](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#debug) information (such as linenumbers)
 - `artifact-name-1.0-debug.jar` the classified jar which contains classes compiled with [debugging](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#debug) information, so will be larger
-- `artifact-name-1.0-site.pdf` a pdf which contains an export of the site documentation\. 
+- `artifact-name-1.0-site.pdf` a pdf which contains an export of the site documentation. 
 
-You can deploy the main artifact and the classified artifacts in a single run\. Let&apos;s assume the original filename for the documentation is `site.pdf`: 
+You can deploy the main artifact and the classified artifacts in a single run. Let&apos;s assume the original filename for the documentation is `site.pdf`: 
 
 ```unknown
 mvn ${project.groupId}:${project.artifactId}:${project.version}:deploy-file -Durl=http://localhost:8081/repomanager/ \
@@ -54,5 +54,5 @@ mvn ${project.groupId}:${project.artifactId}:${project.version}:deploy-file -Dur
                                                                             -Dclassifier=bin
 ```
 
-**Note**: By using the fully qualified path of a goal, you&apos;re ensured to be using the preferred version of the maven\-deploy\-plugin\. When using `mvn deploy:deploy-file` its version depends on its specification in the pom or the version of Apache Maven\.
+**Note**: By using the fully qualified path of a goal, you&apos;re ensured to be using the preferred version of the maven-deploy-plugin. When using `mvn deploy:deploy-file` its version depends on its specification in the pom or the version of Apache Maven.
 

--- a/src/site/markdown/examples/deploying-with-customized-pom.md.vm
+++ b/src/site/markdown/examples/deploying-with-customized-pom.md.vm
@@ -24,7 +24,7 @@ date: 2006-06-21
 
 # Deploy an artifact with a customized pom
 
-If there is already an existing pom and want it to be deployed together with the 3rd party artifact, set the **pomFile** parameter to the path of the pom\.xml\.
+If there is already an existing pom and want it to be deployed together with the 3rd party artifact, set the **pomFile** parameter to the path of the pom.xml.
 
 ```unknown
 mvn ${project.groupId}:${project.artifactId}:${project.version}:deploy-file -Durl=file:///C:/m2-repo \
@@ -33,7 +33,7 @@ mvn ${project.groupId}:${project.artifactId}:${project.version}:deploy-file -Dur
                                                                             -DpomFile=path-to-your-pom.xml
 ```
 
-Note that the groupId, artifactId, version and packaging informations are automatically retrieved from the given pom\.
+Note that the groupId, artifactId, version and packaging informations are automatically retrieved from the given pom.
 
-**Note**: By using the fully qualified path of a goal, you&apos;re ensured to be using the preferred version of the maven\-deploy\-plugin\. When using `mvn deploy:deploy-file` its version depends on its specification in the pom or the version of Apache Maven\.
+**Note**: By using the fully qualified path of a goal, you&apos;re ensured to be using the preferred version of the maven-deploy-plugin. When using `mvn deploy:deploy-file` its version depends on its specification in the pom or the version of Apache Maven.
 

--- a/src/site/markdown/examples/disabling-generic-pom.md.vm
+++ b/src/site/markdown/examples/disabling-generic-pom.md.vm
@@ -24,7 +24,7 @@ date: 2006-06-21
 
 # Disable the generation of pom
 
-By default, If no pom is specified during deployment of your 3rd party artifact, a generic pom will be generated which contains the minimum required elements needed for the pom\. In order to disable it, set the **generatePom** parameter to `false`\.
+By default, If no pom is specified during deployment of your 3rd party artifact, a generic pom will be generated which contains the minimum required elements needed for the pom. In order to disable it, set the **generatePom** parameter to `false`.
 
 ```unknown
 mvn ${project.groupId}:${project.artifactId}:${project.version}:deploy-file -Durl=file:///C:/m2-repo \
@@ -37,5 +37,5 @@ mvn ${project.groupId}:${project.artifactId}:${project.version}:deploy-file -Dur
                                                                             -DgeneratePom=false
 ```
 
-**Note**: By using the fully qualified path of a goal, you&apos;re ensured to be using the preferred version of the maven\-deploy\-plugin\. When using `mvn deploy:deploy-file` its version depends on its specification in the pom or the version of Apache Maven\.
+**Note**: By using the fully qualified path of a goal, you&apos;re ensured to be using the preferred version of the maven-deploy-plugin. When using `mvn deploy:deploy-file` its version depends on its specification in the pom or the version of Apache Maven.
 

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -24,34 +24,34 @@ date: 2013-07-22
 
 # ${project.name}
 
-The deploy plugin is primarily used during the deploy phase, to add your artifact\(s\) to a remote repository for sharing with other developers and projects\. This is usually done in an integration or release environment\. It can also be used to deploy a particular artifact \(e\.g\. a third party jar like Sun&apos;s non redistributable reference implementations\)\.
+The deploy plugin is primarily used during the deploy phase, to add your artifact(s) to a remote repository for sharing with other developers and projects. This is usually done in an integration or release environment. It can also be used to deploy a particular artifact (e.g. a third party jar like Sun&apos;s non redistributable reference implementations).
 
-As a repository contains more than JAR files \(POMs, the metadata, MD5 and SHA1 hash files\.\.\.\), deploying means not only uploading a single file, but making sure all associated artifacts are correctly updated as well\. This is the reponsibility of the deploy plugin\.
+As a repository contains more than JAR files (POMs, the metadata, MD5 and SHA1 hash files\.\.\.), deploying means not only uploading a single file, but making sure all associated artifacts are correctly updated as well. This is the reponsibility of the deploy plugin.
 
 To work, the deployment will require:
 
-- information about the repository: its location, the transport method used to access it \(FTP, SCP, SFTP\.\.\.\) and the optional user specific required account information
-- information about the artifact\(s\): the group, artifact, version, packaging, classifier\.\.\.
-- a deployer: a method to actually perform the deployment\. This can be implemented as a wagon transport \(making it cross\-platform\), or use a system specific method\.
+- information about the repository: its location, the transport method used to access it (FTP, SCP, SFTP\.\.\.) and the optional user specific required account information
+- information about the artifact(s): the group, artifact, version, packaging, classifier\.\.\.
+- a deployer: a method to actually perform the deployment. This can be implemented as a wagon transport (making it cross-platform), or use a system specific method.
 
-The information will be taken from the implied \(or specified\) pom and from the command line\. The settings\.xml file may also be parsed to retrieve user credentials\.
+The information will be taken from the implied (or specified) pom and from the command line. The settings.xml file may also be parsed to retrieve user credentials.
 
 Goals Overview
 -------
 
 The deploy plugin has 2 goals:
 
-- [deploy:deploy](./deploy-mojo.html) is used to automatically install the artifact, its pom, and the attached artifacts produced by a particular project\. Most if not all of the information related to the deployment is stored in the project&apos;s pom\.
-- [deploy:deploy\-file](./deploy-file-mojo.html) is used to install a single artifact along with its pom\. In that case, the artifact information can be taken from an optionally specified pomFile, but can be completed/overridden using the command line\.
+- [deploy:deploy](./deploy-mojo.html) is used to automatically install the artifact, its pom, and the attached artifacts produced by a particular project. Most if not all of the information related to the deployment is stored in the project&apos;s pom.
+- [deploy:deploy-file](./deploy-file-mojo.html) is used to install a single artifact along with its pom. In that case, the artifact information can be taken from an optionally specified pomFile, but can be completed/overridden using the command line.
 
 Usage
 -------
 
-General instructions on how to use the Deploy Plugin can be found on the [usage page](./usage.html)\. Some more specific use cases are described in the examples given below\.
+General instructions on how to use the Deploy Plugin can be found on the [usage page](./usage.html). Some more specific use cases are described in the examples given below.
 
-If you have questions about the plugin&apos;s usage, please read the [FAQ](./faq.html) and feel free to contact the [user mailing list](./mailing-lists.html)\. Posts to the mailing list are archived and could already contain the answer to your question as part of an older thread\. Hence, it is also worth browsing/searching the [mail archive](./mailing-lists.html)\.
+If you have questions about the plugin&apos;s usage, please read the [FAQ](./faq.html) and feel free to contact the [user mailing list](./mailing-lists.html). Posts to the mailing list are archived and could already contain the answer to your question as part of an older thread. Hence, it is also worth browsing/searching the [mail archive](./mailing-lists.html).
 
-If you think the plugin is missing a feature or has a defect, you can file a feature request or bug report in our [issue tracker](./issue-management.html)\. When creating a new issue, please provide a comprehensive description of your concern\. Especially for fixing bugs, it is crucial that the developers can reproduce your problem\. For this reason, entire debug logs, POMs, or most preferably little demo projects attached to the issue are very much appreciated\. Of course, patches are welcome, too\. Contributors can check out the project from our [source repository](./scm.html) and will find supplementary information in the [guide to helping with Maven](https://maven.apache.org/guides/development/guide-helping.html)\.
+If you think the plugin is missing a feature or has a defect, you can file a feature request or bug report in our [issue tracker](./issue-management.html). When creating a new issue, please provide a comprehensive description of your concern. Especially for fixing bugs, it is crucial that the developers can reproduce your problem. For this reason, entire debug logs, POMs, or most preferably little demo projects attached to the issue are very much appreciated. Of course, patches are welcome, too. Contributors can check out the project from our [source repository](./scm.html) and will find supplementary information in the [guide to helping with Maven](https://maven.apache.org/guides/development/guide-helping.html).
 
 Examples
 --------

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -27,15 +27,15 @@ date: 2006-01-29
 
 ## Introduction
 
-The Deploy Plugin has two basic functions\. In most project builds, the `deploy` phase of the build lifecycle is implemented using the `deploy:deploy` mojo\. Also, artifacts which are not built using Maven can be added to any remote repository using the `deploy:deploy-file` mojo\.
+The Deploy Plugin has two basic functions. In most project builds, the `deploy` phase of the build lifecycle is implemented using the `deploy:deploy` mojo. Also, artifacts which are not built using Maven can be added to any remote repository using the `deploy:deploy-file` mojo.
 
 ## The `deploy:deploy` Mojo
 
-In most cases, this mojo is invoked when you call the `deploy` phase of the default build lifecycle\.
+In most cases, this mojo is invoked when you call the `deploy` phase of the default build lifecycle.
 
-To enable this mojo to function, you must include a valid `<distributionManagement/>` section POM, which at the minimum provides a `<repository/>` defining the remote repository location for your artifact\. To separate snapshot artifacts from release artifacts, you can also specify a `<snapshotRepository/>` location\. Finally, to deploy a project website, you must specify a `<site/>` section here as well\. It&apos;s also important to note that this section can be inherited, allowing you to specify the deployment location one time for a set of related projects\.
+To enable this mojo to function, you must include a valid `<distributionManagement/>` section POM, which at the minimum provides a `<repository/>` defining the remote repository location for your artifact. To separate snapshot artifacts from release artifacts, you can also specify a `<snapshotRepository/>` location. Finally, to deploy a project website, you must specify a `<site/>` section here as well. It&apos;s also important to note that this section can be inherited, allowing you to specify the deployment location one time for a set of related projects.
 
-If your repository is secured, you may also want to configure your `settings.xml` file to define corresponding `<server/>` entries which provides authentication information\. Server entries are matched to the different parts of the distributionManagement using their `<id/>` elements\. For example, your project may have a distributionManagement section similar to the following:
+If your repository is secured, you may also want to configure your `settings.xml` file to define corresponding `<server/>` entries which provides authentication information. Server entries are matched to the different parts of the distributionManagement using their `<id/>` elements. For example, your project may have a distributionManagement section similar to the following:
 
 ```unknown
 [...]
@@ -49,7 +49,7 @@ If your repository is secured, you may also want to configure your `settings.xml
 [...]
 ```
 
-In this case, you can specify a server definition in your `settings.xml` to provide authentication information for both of these repositories at once\. Your server section might look like this:
+In this case, you can specify a server definition in your `settings.xml` to provide authentication information for both of these repositories at once. Your server section might look like this:
 
 ```unknown
 [...]
@@ -61,7 +61,7 @@ In this case, you can specify a server definition in your `settings.xml` to prov
 [...]
 ```
 
-Please see the article about [Password Encryption](https://maven.apache.org/guides/mini/guide-encryption.html) for instructions on how to avoid clear text passwords in the `settings.xml`\.
+Please see the article about [Password Encryption](https://maven.apache.org/guides/mini/guide-encryption.html) for instructions on how to avoid clear text passwords in the `settings.xml`.
 
 Once you&apos;ve configured your repository deployment information correctly deploying your project&apos;s artifact will only require invocation of the `deploy` phase of the build:
 
@@ -71,7 +71,7 @@ mvn deploy
 
 ## The `deploy:deploy-file` Mojo
 
-The `deploy:deploy-file` mojo is used primarily for deploying artifacts, which were not built by Maven\. The project&apos;s development team may or may not provide a POM for the artifact, and in some cases you may want to deploy the artifact to an internal remote repository\. The deploy\-file mojo provides functionality covering all of these use cases, and offers a wide range of configurability for generating a POM on\-the\-fly\. Additionally, you can specify what layout your repository uses\. The full usage statement of the deploy\-file mojo can be described as:
+The `deploy:deploy-file` mojo is used primarily for deploying artifacts, which were not built by Maven. The project&apos;s development team may or may not provide a POM for the artifact, and in some cases you may want to deploy the artifact to an internal remote repository. The deploy-file mojo provides functionality covering all of these use cases, and offers a wide range of configurability for generating a POM on-the-fly. Additionally, you can specify what layout your repository uses. The full usage statement of the deploy-file mojo can be described as:
 
 ```unknown
 mvn deploy:deploy-file -Durl=file://C:\m2-repo \
@@ -91,5 +91,5 @@ mvn deploy:deploy-file -Durl=file://C:\m2-repo \
 If the following required information is not specified in some way, the goal will fail:
 
 - the artifact file to deploy
-- the group, artifact, version and packaging of the file to deploy\. These can be taken from the specified pomFile, and overriden or specified using the command line\. When the pomFile contains a _parent_ section, the parent&apos;s groupId can be considered if the groupId is not specified further for the current project or on the command line\.
-- the repository information: the url to deploy to and the repositoryId mapping to a server section in the settings\.xml file\. If you don&apos;t specify a repositoryId, Maven will try to extract authentication information using the id `'remote-repository'`\.
+- the group, artifact, version and packaging of the file to deploy. These can be taken from the specified pomFile, and overriden or specified using the command line. When the pomFile contains a _parent_ section, the parent&apos;s groupId can be considered if the groupId is not specified further for the current project or on the command line.
+- the repository information: the url to deploy to and the repositoryId mapping to a server section in the settings.xml file. If you don&apos;t specify a repositoryId, Maven will try to extract authentication information using the id `'remote-repository'`.


### PR DESCRIPTION
Pages converted from APT with an older `doxia-converter` carry a backslash in front of
punctuation that is not markup where it stands, for example `maven\-source\-plugin`,
`\(default\)` and `required\.`. The backslash renders as nothing; it only makes the source
harder to read and to edit, which was the point of moving to Markdown.

Only positions where the bare character can never be markup are touched: a hyphen,
underscore or asterisk between two word characters, a parenthesis, a full stop that
does not follow a digit, and an exclamation mark not followed by `[`.

Left alone deliberately:

* angle brackets, since `<escapeString>` really would be read as an HTML tag
* a full stop after a digit, so an ordered list marker cannot appear by accident
* a run of dots, because bare `...` is rendered as a single ellipsis character
* code spans, fenced blocks and link destinations

Verified by building the site before and after: every generated page is identical in
its visible text and in every link target.