### PR TITLE
Restore the plain form of the ASF licence header

### DIFF
--- a/src/site/markdown/examples/deploy-ftp.md
+++ b/src/site/markdown/examples/deploy-ftp.md
@@ -14,7 +14,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/src/site/markdown/examples/deploy-ftp.md
+++ b/src/site/markdown/examples/deploy-ftp.md
@@ -5,22 +5,24 @@ author:
 date: 2005-10-12
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Deployment of artifacts with FTP
 

--- a/src/site/markdown/examples/deploy-http.md
+++ b/src/site/markdown/examples/deploy-http.md
@@ -14,7 +14,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/src/site/markdown/examples/deploy-http.md
+++ b/src/site/markdown/examples/deploy-http.md
@@ -5,22 +5,24 @@ author:
 date: 2025-09-17
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Deployment of artifacts with HTTP(S)
 

--- a/src/site/markdown/examples/deploy-network-issues.md
+++ b/src/site/markdown/examples/deploy-network-issues.md
@@ -14,7 +14,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/src/site/markdown/examples/deploy-network-issues.md
+++ b/src/site/markdown/examples/deploy-network-issues.md
@@ -5,22 +5,24 @@ author:
 date: 2019-01-20
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Deploying With Network Issues
 

--- a/src/site/markdown/examples/deploy-ssh-external.md
+++ b/src/site/markdown/examples/deploy-ssh-external.md
@@ -14,7 +14,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/src/site/markdown/examples/deploy-ssh-external.md
+++ b/src/site/markdown/examples/deploy-ssh-external.md
@@ -5,22 +5,24 @@ author:
 date: 2005-10-12
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Deployment of artifacts in an external SSH command
 

--- a/src/site/markdown/examples/deploying-in-legacy-layout.md.vm
+++ b/src/site/markdown/examples/deploying-in-legacy-layout.md.vm
@@ -14,7 +14,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/src/site/markdown/examples/deploying-in-legacy-layout.md.vm
+++ b/src/site/markdown/examples/deploying-in-legacy-layout.md.vm
@@ -5,22 +5,24 @@ author:
 date: 2006-06-21
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Deploy an artifact in legacy layout
 

--- a/src/site/markdown/examples/deploying-sources-javadoc.md.vm
+++ b/src/site/markdown/examples/deploying-sources-javadoc.md.vm
@@ -3,22 +3,24 @@ title: Deploy sources and javadocs for an artifact
 date: 20011-02-23
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Deploy sources and javadoc jars
 

--- a/src/site/markdown/examples/deploying-sources-javadoc.md.vm
+++ b/src/site/markdown/examples/deploying-sources-javadoc.md.vm
@@ -12,7 +12,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/src/site/markdown/examples/deploying-with-classifiers.md.vm
+++ b/src/site/markdown/examples/deploying-with-classifiers.md.vm
@@ -14,7 +14,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/src/site/markdown/examples/deploying-with-classifiers.md.vm
+++ b/src/site/markdown/examples/deploying-with-classifiers.md.vm
@@ -5,22 +5,24 @@ author:
 date: 2013-09-01
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Deploy an artifact with classifier
 

--- a/src/site/markdown/examples/deploying-with-customized-pom.md.vm
+++ b/src/site/markdown/examples/deploying-with-customized-pom.md.vm
@@ -14,7 +14,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/src/site/markdown/examples/deploying-with-customized-pom.md.vm
+++ b/src/site/markdown/examples/deploying-with-customized-pom.md.vm
@@ -5,22 +5,24 @@ author:
 date: 2006-06-21
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Deploy an artifact with a customized pom
 

--- a/src/site/markdown/examples/disabling-generic-pom.md.vm
+++ b/src/site/markdown/examples/disabling-generic-pom.md.vm
@@ -14,7 +14,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/src/site/markdown/examples/disabling-generic-pom.md.vm
+++ b/src/site/markdown/examples/disabling-generic-pom.md.vm
@@ -5,22 +5,24 @@ author:
 date: 2006-06-21
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Disable the generation of pom
 

--- a/src/site/markdown/file-deployment.md
+++ b/src/site/markdown/file-deployment.md
@@ -14,7 +14,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/src/site/markdown/file-deployment.md
+++ b/src/site/markdown/file-deployment.md
@@ -5,22 +5,24 @@ author:
 date: 2006-07-14
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # File Deployment
 

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -14,7 +14,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -5,22 +5,24 @@ author:
 date: 2013-07-22
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # ${project.name}
 

--- a/src/site/markdown/project-deployment.md
+++ b/src/site/markdown/project-deployment.md
@@ -14,7 +14,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/src/site/markdown/project-deployment.md
+++ b/src/site/markdown/project-deployment.md
@@ -5,22 +5,24 @@ author:
 date: 2006-07-14
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Project Deployment
 

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -6,22 +6,24 @@ author:
 date: 2006-01-29
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Usage
 

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -15,7 +15,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an


### PR DESCRIPTION
An earlier APT to Markdown conversion left the header as one HTML comment
per line, and in one page as a Java block comment wrapped in an HTML
comment. Both are hard to read and neither matches the header every other
file in the project carries.

They are now the plain block form. RAT still recognises it.

<sub>Drafted with Claude — please verify</sub>