### PR TITLE
Restore the plain form of the ASF licence header

### DIFF
--- a/src/site/markdown/examples/deploy-ftp.md
+++ b/src/site/markdown/examples/deploy-ftp.md
@@ -5,22 +5,24 @@ author:
 date: 2005-10-12
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Deployment of artifacts with FTP
 

--- a/src/site/markdown/examples/deploy-http.md
+++ b/src/site/markdown/examples/deploy-http.md
@@ -5,22 +5,24 @@ author:
 date: 2025-09-17
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Deployment of artifacts with HTTP(S)
 

--- a/src/site/markdown/examples/deploy-network-issues.md
+++ b/src/site/markdown/examples/deploy-network-issues.md
@@ -5,22 +5,24 @@ author:
 date: 2019-01-20
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Deploying With Network Issues
 

--- a/src/site/markdown/examples/deploy-ssh-external.md
+++ b/src/site/markdown/examples/deploy-ssh-external.md
@@ -5,22 +5,24 @@ author:
 date: 2005-10-12
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Deployment of artifacts in an external SSH command
 

--- a/src/site/markdown/file-deployment.md
+++ b/src/site/markdown/file-deployment.md
@@ -5,22 +5,24 @@ author:
 date: 2006-07-14
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # File Deployment
 

--- a/src/site/markdown/project-deployment.md
+++ b/src/site/markdown/project-deployment.md
@@ -5,22 +5,24 @@ author:
 date: 2006-07-14
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Project Deployment
 

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -6,22 +6,24 @@ author:
 date: 2006-01-29
 ---
 
-<!-- Licensed to the Apache Software Foundation (ASF) under one-->
-<!-- or more contributor license agreements.  See the NOTICE file-->
-<!-- distributed with this work for additional information-->
-<!-- regarding copyright ownership.  The ASF licenses this file-->
-<!-- to you under the Apache License, Version 2.0 (the-->
-<!-- "License"); you may not use this file except in compliance-->
-<!-- with the License.  You may obtain a copy of the License at-->
-<!---->
-<!--   http://www.apache.org/licenses/LICENSE-2.0-->
-<!---->
-<!-- Unless required by applicable law or agreed to in writing,-->
-<!-- software distributed under the License is distributed on an-->
-<!-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY-->
-<!-- KIND, either express or implied.  See the License for the-->
-<!-- specific language governing permissions and limitations-->
-<!-- under the License.-->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 
 # Usage
 


### PR DESCRIPTION
Port of #687 to the `maven-deploy-plugin-3.x` line, which carries the same seven pages with the same one-HTML-comment-per-line header.

An earlier APT to Markdown conversion left the header as one comment per line. That is hard to read and does not match the header every other file in the project carries. They are now the plain block form, with the licence URL indented by two spaces exactly as `pom.xml` has it. RAT still recognises it.

The maintenance line is live — last commit 2026-07-28 — so it is worth keeping in step with master.

Draft until CI is green.

<sub>Drafted with Claude — please verify</sub>