### PR TITLE
Cache projectsWithDeployExecution to fix O(N²) reactor scan

### DIFF
--- a/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java
+++ b/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java
@@ -21,12 +21,13 @@ package org.apache.maven.plugins.deploy;
 import javax.inject.Inject;
 
 import java.io.File;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.ArtifactUtils;
@@ -166,6 +167,8 @@ public class DeployMojo extends AbstractDeployMojo {
     private static final String DEPLOY_ALT_DEPLOYMENT_REPOSITORY =
             DeployMojo.class.getName() + ".altDeploymentRepository";
 
+    private static final String PROJECTS_WITH_DEPLOY_KEY = DeployMojo.class.getName() + ".projectsWithDeploy";
+
     private void putState(State state) {
         getPluginContext().put(DEPLOY_PROCESSED_MARKER, state.name());
     }
@@ -264,6 +267,22 @@ public class DeployMojo extends AbstractDeployMojo {
         }
     }
 
+    /**
+     * Returns the list of reactor projects that have a deploy execution, cached on first call.
+     * The list is invariant during a build and is stored in the first reactor project's plugin
+     * context to avoid recomputing it on every module invocation (O(N) total instead of O(N²)).
+     */
+    @SuppressWarnings("unchecked")
+    private List<MavenProject> getProjectsWithDeployExecution() {
+        if (reactorProjects.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Map<String, Object> pluginContext = session.getPluginContext(pluginDescriptor, reactorProjects.get(0));
+        return (List<MavenProject>) pluginContext.computeIfAbsent(
+                PROJECTS_WITH_DEPLOY_KEY,
+                k -> reactorProjects.stream().filter(this::hasDeployExecution).collect(Collectors.toList()));
+    }
+
     private boolean allProjectsMarked(List<MavenProject> allProjectsUsingPlugin) {
         for (MavenProject reactorProject : allProjectsUsingPlugin) {
             if (!hasState(reactorProject)) {
@@ -274,13 +293,11 @@ public class DeployMojo extends AbstractDeployMojo {
     }
 
     private List<MavenProject> getAllProjectsUsingPlugin() {
-        ArrayList<MavenProject> result = new ArrayList<>();
-        for (MavenProject reactorProject : reactorProjects) {
-            if (hasExecution(reactorProject.getPlugin("org.apache.maven.plugins:maven-deploy-plugin"))) {
-                result.add(reactorProject);
-            }
-        }
-        return result;
+        return getProjectsWithDeployExecution();
+    }
+
+    private boolean hasDeployExecution(MavenProject project) {
+        return hasExecution(project.getPlugin("org.apache.maven.plugins:maven-deploy-plugin"));
     }
 
     private boolean hasExecution(Plugin plugin) {


### PR DESCRIPTION
* Cache projectsWithDeployExecution list to avoid O(N²) reactor scan

DeployMojo.allProjectsMarked() calls hasDeployExecution() for every reactor project on every module invocation. hasDeployExecution() calls getPluginsAsMap() for each project, producing O(N²) evaluations in a large reactor build (e.g., 4383² ≈ 19.2M calls in a 4383-module project).

Fix: cache the filtered list of projects with deploy executions in the first reactor project's plugin context. The list is invariant during a build. Also simplify allProjectsMarked() to only check the projects that actually have deploy executions, rather than iterating the full reactor and testing the disjunction (hasState || !hasDeployExecution).



* fix: synchronize cache population for parallel builds

The get/check/put on the plugin context map is a TOCTOU race — in parallel builds (-T), multiple threads can see the cache as null and each recompute the full reactor scan, defeating the cache.

Wrap the compound operation in synchronized(ctx) so only the first thread computes and all others reuse the result. Session.getPluginContext() returns Map (not ConcurrentMap), so synchronized is the safest choice that does not depend on the underlying implementation.



* refactor: use computeIfAbsent instead of synchronized block

Replace the synchronized get/check/put with a single computeIfAbsent call. The plugin context map is a ConcurrentHashMap at runtime, so computeIfAbsent is atomic and guarantees single-invocation. Even if the underlying Map implementation changed, the worst case is redundant computation of the same invariant list — a perf regression, not a bug.



- https://github.com/apache/maven-deploy-plugin/pull/684